### PR TITLE
Created and moved some variables to facilitate setting build-time defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ FILES     := $$(find . -name "*.go")
 FAILPOINT_ENABLE  := $$(find $$PWD/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl enable)
 FAILPOINT_DISABLE := $$(find $$PWD/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl disable)
 
-default: cmd
+default: check cmd
 
-cmd: check
+cmd:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tiup
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ LDFLAGS := -w -s
 LDFLAGS += -X "$(REPO)/pkg/version.GitHash=$(COMMIT)"
 LDFLAGS += -X "$(REPO)/pkg/version.GitBranch=$(BRANCH)"
 LDFLAGS += -X "$(REPO)/pkg/version.BuildTime=$(BUILDTIME)"
+LDFLAGS += $(EXTRA_LDFLAGS)
 
 FILES     := $$(find . -name "*.go")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,8 +26,6 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const profileDirName = ".tiup"
-
 var (
 	profile    *localdata.Profile
 	rootCmd    *cobra.Command
@@ -125,7 +123,16 @@ func execute() error {
 	}
 
 	// Initialize the global profile
-	profile = localdata.NewProfile(filepath.Join(u.HomeDir, profileDirName))
+	var profileDir string
+	switch {
+	case os.Getenv(localdata.EnvNameHome) != "":
+		profileDir = os.Getenv(localdata.EnvNameHome)
+	case localdata.DefaultTiupHome != "":
+		profileDir = localdata.DefaultTiupHome
+	default:
+		profileDir = filepath.Join(u.HomeDir, localdata.ProfileDirName)
+	}
+	profile = localdata.NewProfile(profileDir)
 
 	// Initialize the repository
 	// Replace the mirror if some subcommands use different mirror address

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -211,8 +211,8 @@ func launchComponent(ctx context.Context, component string, version meta.Version
 	// init the command
 	c := exec.CommandContext(ctx, binPath, args...)
 	c.Env = append(
-		os.Environ(),
-		envs...,
+		envs,
+		os.Environ()...,
 	)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr

--- a/pkg/localdata/constant.go
+++ b/pkg/localdata/constant.go
@@ -28,4 +28,12 @@ const (
 
 	// MetaFilename represents the process meta file name
 	MetaFilename = "tiup_process_meta"
+
+	// ProfileDirName is the name of the profile directory to be used
+	ProfileDirName = ".tiup"
+
+	// DefaultTiupHome represents the default home directory for this build of tiup
+	// If this is left empty, the default will be thee combination of the running
+	// user's home directory and ProfileDirName
+	DefaultTiupHome = ""
 )

--- a/pkg/localdata/constant.go
+++ b/pkg/localdata/constant.go
@@ -13,6 +13,14 @@
 
 package localdata
 
+// DefaultTiupHome represents the default home directory for this build of tiup
+// If this is left empty, the default will be thee combination of the running
+// user's home directory and ProfileDirName
+var DefaultTiupHome string
+
+// ProfileDirName is the name of the profile directory to be used
+var ProfileDirName = ".tiup"
+
 const (
 	// ComponentParentDir represent the parent directory of all downloaded components
 	ComponentParentDir = "components"
@@ -28,12 +36,4 @@ const (
 
 	// MetaFilename represents the process meta file name
 	MetaFilename = "tiup_process_meta"
-
-	// ProfileDirName is the name of the profile directory to be used
-	ProfileDirName = ".tiup"
-
-	// DefaultTiupHome represents the default home directory for this build of tiup
-	// If this is left empty, the default will be thee combination of the running
-	// user's home directory and ProfileDirName
-	DefaultTiupHome = ""
 )


### PR DESCRIPTION
This PR changes the way the profile directory is populated. The new behavior should match the old behavior for the default case.

`TIUP_HOME` was not being propagated correctly because of the order of environment assignment; that's fixed in this PR.

This PR adds DefaultTiupHome and ProfileDirName variables to pkg/localdata/constant.go to allow a build-time ldflags -X flag to set the variable. The Makefile adds EXTRA_LDFLAGS to further support this. This is useful for environments like homebrew where the tiup binary itself should be built to have a default directory outside the home directory of the installing user.

This new behavior can be achieved by executing something like this:
```
make EXTRA_LDFLAGS='-X "github.com/pingcap-incubator/tiup/pkg/localdata.DefaultTiupHome=/usr/local/var/tiup"'
```