### PR TITLE
cmd: fix mirror flag and add a new flag for disabling semver check

### DIFF
--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -39,7 +39,7 @@ func currentDir() string {
 
 func (s *metaSuite) TestRepository(c *C) {
 	testDir := filepath.Join(currentDir(), "testdata")
-	repo := NewRepository(NewMirror(testDir))
+	repo := NewRepository(NewMirror(testDir), RepositoryOptions{})
 	comps, err := repo.Manifest()
 	c.Assert(err, IsNil)
 

--- a/pkg/meta/repository.go
+++ b/pkg/meta/repository.go
@@ -36,11 +36,17 @@ const (
 // Repository represents a components repository
 type Repository struct {
 	mirror Mirror
+	opts   RepositoryOptions
+}
+
+// RepositoryOptions represents options for a repository
+type RepositoryOptions struct {
+	SkipVersionCheck bool
 }
 
 // NewRepository returns a repository instance base on mirror
-func NewRepository(mirror Mirror) *Repository {
-	return &Repository{mirror: mirror}
+func NewRepository(mirror Mirror, opts RepositoryOptions) *Repository {
+	return &Repository{mirror: mirror, opts: opts}
 }
 
 // Mirror returns the mirror which is used by repository
@@ -117,7 +123,7 @@ func (r *Repository) DownloadComponent(compsDir, spec string) error {
 			return fmt.Errorf("component `%s` doesn't release the version `%s`", component, version)
 		}
 	}
-	if !version.IsNightly() && !version.IsValid() {
+	if !r.opts.SkipVersionCheck && !version.IsNightly() && !version.IsValid() {
 		return errors.Errorf("invalid version `%s`", version)
 	}
 	resName := fmt.Sprintf("%s-%s", component, version)


### PR DESCRIPTION
This PR includes two changes:
1. mirror flag actually cannot work properly because it take effect after initialization of repo, thus fix it.
2. current version check is somehow too strict, add an another flag for disabling it (temporarily).