### PR TITLE
cmd: fix help doc and run bug

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,7 +55,7 @@ func init() {
 		Use: "tiup [component]|[command]",
 		Long: `The tiup is a component management CLI utility tool that can help to download and install
 the TiDB components to the local system. You can run a specific version of a component via
-"tiup <component>:[version]" If no version number is specified, the latest version installed
+"tiup <component>:[version]". If no version number is specified, the latest version installed
 locally will be run. If the specified component does not have any version installed locally,
 the latest stable version will be downloaded from the repository. You can run the following
 commands if you want to have a try.
@@ -98,12 +98,12 @@ commands if you want to have a try.
 		SilenceUsage: true,
 	}
 
-	rootCmd.PersistentFlags().StringVarP(&mirrorRepository, "mirror", "", mirror, "Overwrite default `mirror` or TIUP_MIRRORS environment variable.")
-	rootCmd.PersistentFlags().BoolVarP(&repoOpts.SkipVersionCheck, "skip-version-check", "", false, "Skip the strict version check, by default a version must be a valid semver string.")
+	rootCmd.PersistentFlags().StringVarP(&mirrorRepository, "mirror", "", mirror, "Overwrite default `mirror` or TIUP_MIRRORS environment variable")
+	rootCmd.PersistentFlags().BoolVarP(&repoOpts.SkipVersionCheck, "skip-version-check", "", false, "Skip the strict version check, by default a version must be a valid SemVer string")
 	rootCmd.Flags().StringVarP(&binary, "binary", "B", "", "Print binary path of a specific version of a component `<component>:[version]`\n"+
-		"and the latest version installed will be selected if no version specified.")
+		"and the latest version installed will be selected if no version specified")
 	rootCmd.Flags().StringVarP(&tag, "tag", "T", "", "Specify a tag for component instance")
-	rootCmd.Flags().BoolVar(&rm, "rm", false, "Remove data directory on finish")
+	rootCmd.Flags().BoolVar(&rm, "rm", false, "Remove the data directory when the component instance finishes its run")
 
 	rootCmd.AddCommand(
 		newInstallCmd(),

--- a/components/client/main.go
+++ b/components/client/main.go
@@ -56,7 +56,7 @@ func connect(target string) error {
 		return fmt.Errorf("error on read files: %s", err.Error())
 	}
 	if len(endpoints) == 0 {
-		return fmt.Errorf("It seems no playground is running, execute `tiup run playground` to start one")
+		return fmt.Errorf("It seems no playground is running, execute `tiup playground` to start one")
 	}
 	var ep *endpoint
 	if target == "" {

--- a/components/package/main.go
+++ b/components/package/main.go
@@ -186,17 +186,16 @@ func componentIndex(name, desc, entry, version, goos, goarch string) error {
 		if cIndex.Nightly == nil {
 			cIndex.Nightly = &v
 			return write("package/"+fname, cIndex)
-		} else {
-			cIndex.Nightly.Date = time.Now()
-			cIndex.Nightly.Entry = entry
-			for _, p := range cIndex.Nightly.Platforms {
-				if p == pair {
-					return write("package/"+fname, cIndex)
-				}
-			}
-			cIndex.Nightly.Platforms = append(cIndex.Nightly.Platforms, pair)
-			return write("package/"+fname, cIndex)
 		}
+		cIndex.Nightly.Date = time.Now()
+		cIndex.Nightly.Entry = entry
+		for _, p := range cIndex.Nightly.Platforms {
+			if p == pair {
+				return write("package/"+fname, cIndex)
+			}
+		}
+		cIndex.Nightly.Platforms = append(cIndex.Nightly.Platforms, pair)
+		return write("package/"+fname, cIndex)
 	}
 
 	cIndex.Versions = append(cIndex.Versions, v)
@@ -206,9 +205,8 @@ func componentIndex(name, desc, entry, version, goos, goarch string) error {
 func join(url, file string) string {
 	if strings.HasSuffix(url, "/") {
 		return url + file
-	} else {
-		return url + "/" + file
 	}
+	return url + "/" + file
 }
 
 func write(file string, data interface{}) error {

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
                 <br />
 
                 <p>Start a local cluster</p>
-                <pre><code> tiup run playground </code></pre>
+                <pre><code> tiup playground </code></pre>
                 <br />
 
                 <p>This tool only supports Linux/MacOS/Windows WSL(for now)</p>

--- a/install.sh
+++ b/install.sh
@@ -64,5 +64,5 @@ esac
 
 echo "Installed path: ${bold}$bin_dir/tiup${sgr0}"
 echo "==============================================="
-echo "Have a try:     ${bold}tiup run playground${sgr0}"
+echo "Have a try:     ${bold}tiup playground${sgr0}"
 echo "==============================================="

--- a/tests/expected/tiup/tiup-help-install.output
+++ b/tests/expected/tiup/tiup-help-install.output
@@ -24,5 +24,5 @@ Flags:
   -h, --help   help for install
 
 Global Flags:
-      --mirror mirror        Overwrite default mirror or TIUP_MIRRORS environment variable. (default "TIUP_MIRRORS_INTEGRATION_TEST")
-      --skip-version-check   Skip the strict version check, by default a version must be a valid semver string.
+      --mirror mirror        Overwrite default mirror or TIUP_MIRRORS environment variable (default "TIUP_MIRRORS_INTEGRATION_TEST")
+      --skip-version-check   Skip the strict version check, by default a version must be a valid SemVer string

--- a/tests/expected/tiup/tiup-help.output
+++ b/tests/expected/tiup/tiup-help.output
@@ -1,6 +1,6 @@
 The tiup is a component management CLI utility tool that can help to download and install
 the TiDB components to the local system. You can run a specific version of a component via
-"tiup <component>:[version]" If no version number is specified, the latest version installed
+"tiup <component>:[version]". If no version number is specified, the latest version installed
 locally will be run. If the specified component does not have any version installed locally,
 the latest stable version will be downloaded from the repository. You can run the following
 commands if you want to have a try.
@@ -31,11 +31,11 @@ Available Components:
 
 Flags:
   -B, --binary <component>:[version]   Print binary path of a specific version of a component <component>:[version]
-                                       and the latest version installed will be selected if no version specified.
+                                       and the latest version installed will be selected if no version specified
   -h, --help                           help for tiup
-      --mirror mirror                  Overwrite default mirror or TIUP_MIRRORS environment variable. (default "TIUP_MIRRORS_INTEGRATION_TEST")
-      --rm                             Remove data directory on finish
-      --skip-version-check             Skip the strict version check, by default a version must be a valid semver string.
+      --mirror mirror                  Overwrite default mirror or TIUP_MIRRORS environment variable (default "TIUP_MIRRORS_INTEGRATION_TEST")
+      --rm                             Remove the data directory when the component instance finishes its run
+      --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string
   -T, --tag string                     Specify a tag for component instance
 
 Use "tiup [command] --help" for more information about a command.

--- a/tests/expected/tiup/tiup.output
+++ b/tests/expected/tiup/tiup.output
@@ -1,6 +1,6 @@
 The tiup is a component management CLI utility tool that can help to download and install
 the TiDB components to the local system. You can run a specific version of a component via
-"tiup <component>:[version]" If no version number is specified, the latest version installed
+"tiup <component>:[version]". If no version number is specified, the latest version installed
 locally will be run. If the specified component does not have any version installed locally,
 the latest stable version will be downloaded from the repository. You can run the following
 commands if you want to have a try.
@@ -31,11 +31,11 @@ Available Components:
 
 Flags:
   -B, --binary <component>:[version]   Print binary path of a specific version of a component <component>:[version]
-                                       and the latest version installed will be selected if no version specified.
+                                       and the latest version installed will be selected if no version specified
   -h, --help                           help for tiup
-      --mirror mirror                  Overwrite default mirror or TIUP_MIRRORS environment variable. (default "TIUP_MIRRORS_INTEGRATION_TEST")
-      --rm                             Remove data directory on finish
-      --skip-version-check             Skip the strict version check, by default a version must be a valid semver string.
+      --mirror mirror                  Overwrite default mirror or TIUP_MIRRORS environment variable (default "TIUP_MIRRORS_INTEGRATION_TEST")
+      --rm                             Remove the data directory when the component instance finishes its run
+      --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string
   -T, --tag string                     Specify a tag for component instance
       --version                        version for tiup
 


### PR DESCRIPTION
1. fix help doc
2. fix compiler's complain: ```components/package/main.go:189:10: if block ends with a return statement, so drop this else and outdent its block```
3. fix `tiup run playground`