### PR TITLE
specify component binary path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+vendor/
 bin/
 *.tar
 *.gz

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,14 +15,12 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"strings"
-
 	"github.com/fatih/color"
 	"github.com/pingcap-incubator/tiup/pkg/meta"
 	"github.com/pingcap-incubator/tiup/pkg/repository"
 	"github.com/pingcap-incubator/tiup/pkg/version"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var rootCmd *cobra.Command
@@ -82,15 +80,7 @@ the latest stable version will be downloaded from the repository.
 				componentSpec := args[0]
 				for i, arg := range os.Args {
 					if arg == componentSpec {
-						var num = 1
-						if len(os.Args) > i+1 && strings.HasPrefix(os.Args[i+1], "--binpath=") {
-							num += 1
-							flagLen := len("--binpath=")
-							if len(os.Args[i+1]) > flagLen {
-								binPath = os.Args[i+1][flagLen:]
-							}
-						}
-						transparentParams = os.Args[i+num:]
+						transparentParams = os.Args[i+1:]
 						break
 					}
 				}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,21 +52,24 @@ the latest stable version will be downloaded from the repository.
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		Version:            fmt.Sprintf("%s+%s(%s)", version.NewTiUPVersion().SemVer(), version.GitBranch, version.GitHash),
 		Args: func(cmd *cobra.Command, args []string) error {
-			// Support `tiup <component>`
+			// Support `tiup <component>:[<version>]:[<binpath>]`
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if binary != "" {
-				component, ver := meta.ParseCompVersion(binary)
+				component, ver, binPath := meta.ParseBinary(binary)
 				selectedVer, err := meta.SelectInstalledVersion(component, ver)
 				if err != nil {
 					return err
 				}
-				binaryPath, err := meta.BinaryPath(component, selectedVer)
-				if err != nil {
-					return err
+				if binPath == "" {
+					binPath, err = meta.BinaryPath(component, selectedVer)
+					if err != nil {
+						return err
+					}
 				}
-				fmt.Println(binaryPath)
+
+				fmt.Println(binPath)
 				return nil
 			}
 			if len(args) > 0 {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -33,7 +33,7 @@ import (
 )
 
 func runComponent(tag, spec string, args []string, rm bool) error {
-	component, version := meta.ParseCompVersion(spec)
+	component, version, binPath := meta.ParseBinary(spec)
 	if !isSupportedComponent(component) {
 		return fmt.Errorf("unkonwn component `%s` (see supported components via `tiup list --refresh`)", component)
 	}
@@ -41,7 +41,7 @@ func runComponent(tag, spec string, args []string, rm bool) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	p, err := launchComponent(ctx, component, version, tag, args)
+	p, err := launchComponent(ctx, component, version, binPath, tag, args)
 	// If the process has been launched, we must save the process info to meta directory
 	if err == nil || (p != nil && p.Pid != 0) {
 		defer cleanDataDir(rm, p.Dir)
@@ -134,19 +134,26 @@ func base62Tag() string {
 	return string(b)
 }
 
-func launchComponent(ctx context.Context, component string, version repository.Version, tag string, args []string) (*process, error) {
-	selectVer, err := meta.DownloadComponentIfMissing(component, version)
-	if err != nil {
-		return nil, err
-	}
-	binPath, err := meta.BinaryPath(component, selectVer)
-	if err != nil {
-		return nil, err
-	}
+func launchComponent(ctx context.Context, component string, version repository.Version, binPath string, tag string, args []string) (*process, error) {
+	var selectVer repository.Version
+	var installPath string
+	var err error
 
-	installPath, err := meta.ComponentInstalledDir(component, selectVer)
-	if err != nil {
-		return nil, err
+	if binPath == "" {
+		selectVer, err = meta.DownloadComponentIfMissing(component, version)
+		if err != nil {
+			return nil, err
+		}
+
+		binPath, err = meta.BinaryPath(component, selectVer)
+		if err != nil {
+			return nil, err
+		}
+
+		installPath, err = meta.ComponentInstalledDir(component, selectVer)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	wd := os.Getenv(localdata.EnvNameInstanceDataDir)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -32,8 +32,8 @@ import (
 	"github.com/pingcap/errors"
 )
 
-func runComponent(tag, spec string, args []string, rm bool) error {
-	component, version, binPath := meta.ParseBinary(spec)
+func runComponent(tag, spec, binPath string, args []string, rm bool) error {
+	component, version := meta.ParseCompVersion(spec)
 	if !isSupportedComponent(component) {
 		return fmt.Errorf("unkonwn component `%s` (see supported components via `tiup list --refresh`)", component)
 	}

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -35,6 +35,9 @@ type Instance interface {
 	Wait() error
 }
 
-func specifyBinary(comp string, version repository.Version, binPath string) string {
-	return fmt.Sprintf("%v:%v:%v", comp, version, binPath)
+func compVersion(comp string, version repository.Version) string {
+	if version.IsEmpty() {
+		return comp
+	}
+	return fmt.Sprintf("%v:%v", comp, version)
 }

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -31,13 +31,10 @@ type instance struct {
 // Instance represent running component
 type Instance interface {
 	Pid() int
-	Start(ctx context.Context, version repository.Version) error
+	Start(ctx context.Context, version repository.Version, binPath string) error
 	Wait() error
 }
 
-func compVersion(comp string, version repository.Version) string {
-	if version.IsEmpty() {
-		return comp
-	}
-	return fmt.Sprintf("%v:%v", comp, version)
+func specifyBinary(comp string, version repository.Version, binPath string) string {
+	return fmt.Sprintf("%v:%v:%v", comp, version, binPath)
 }

--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -53,13 +53,13 @@ func (inst *PDInstance) Join(pds []*PDInstance) *PDInstance {
 }
 
 // Start calls set inst.cmd and Start
-func (inst *PDInstance) Start(ctx context.Context, version repository.Version) error {
+func (inst *PDInstance) Start(ctx context.Context, version repository.Version, binPath string) error {
 	if err := os.MkdirAll(inst.Dir, 0755); err != nil {
 		return err
 	}
 	uid := fmt.Sprintf("pd-%d", inst.ID)
 	args := []string{
-		"tiup", compVersion("pd", version),
+		"tiup", specifyBinary("pd", version, binPath),
 		"--name=" + uid,
 		fmt.Sprintf("--data-dir=%s", filepath.Join(inst.Dir, "data")),
 		fmt.Sprintf("--peer-urls=http://%s:%d", inst.Host, inst.Port),

--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -59,8 +59,8 @@ func (inst *PDInstance) Start(ctx context.Context, version repository.Version, b
 	}
 	uid := fmt.Sprintf("pd-%d", inst.ID)
 	args := []string{
-		"tiup", compVersion("pd", version),
-		fmt.Sprintf("--binpath=%s", binPath),
+		"tiup", fmt.Sprintf("--binpath=%s", binPath),
+		compVersion("pd", version),
 		"--name=" + uid,
 		fmt.Sprintf("--data-dir=%s", filepath.Join(inst.Dir, "data")),
 		fmt.Sprintf("--peer-urls=http://%s:%d", inst.Host, inst.Port),

--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -59,7 +59,8 @@ func (inst *PDInstance) Start(ctx context.Context, version repository.Version, b
 	}
 	uid := fmt.Sprintf("pd-%d", inst.ID)
 	args := []string{
-		"tiup", specifyBinary("pd", version, binPath),
+		"tiup", compVersion("pd", version),
+		fmt.Sprintf("--binpath=%s", binPath),
 		"--name=" + uid,
 		fmt.Sprintf("--data-dir=%s", filepath.Join(inst.Dir, "data")),
 		fmt.Sprintf("--peer-urls=http://%s:%d", inst.Host, inst.Port),

--- a/components/playground/instance/tidb.go
+++ b/components/playground/instance/tidb.go
@@ -49,7 +49,7 @@ func NewTiDBInstance(dir, host string, id int, pds []*PDInstance) *TiDBInstance 
 }
 
 // Start calls set inst.cmd and Start
-func (inst *TiDBInstance) Start(ctx context.Context, version repository.Version) error {
+func (inst *TiDBInstance) Start(ctx context.Context, version repository.Version, binPath string) error {
 	if err := os.MkdirAll(inst.Dir, 0755); err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (inst *TiDBInstance) Start(ctx context.Context, version repository.Version)
 		endpoints = append(endpoints, fmt.Sprintf("%s:%d", inst.Host, pd.StatusPort))
 	}
 	args := []string{
-		"tiup", compVersion("tidb", version),
+		"tiup", specifyBinary("tidb", version, binPath),
 		"-P", strconv.Itoa(inst.Port),
 		"--store=tikv",
 		fmt.Sprintf("--host=%s", inst.Host),

--- a/components/playground/instance/tidb.go
+++ b/components/playground/instance/tidb.go
@@ -58,7 +58,8 @@ func (inst *TiDBInstance) Start(ctx context.Context, version repository.Version,
 		endpoints = append(endpoints, fmt.Sprintf("%s:%d", inst.Host, pd.StatusPort))
 	}
 	args := []string{
-		"tiup", specifyBinary("tidb", version, binPath),
+		"tiup", compVersion("tidb", version),
+		fmt.Sprintf("--binpath=%s", binPath),
 		"-P", strconv.Itoa(inst.Port),
 		"--store=tikv",
 		fmt.Sprintf("--host=%s", inst.Host),

--- a/components/playground/instance/tidb.go
+++ b/components/playground/instance/tidb.go
@@ -58,8 +58,8 @@ func (inst *TiDBInstance) Start(ctx context.Context, version repository.Version,
 		endpoints = append(endpoints, fmt.Sprintf("%s:%d", inst.Host, pd.StatusPort))
 	}
 	args := []string{
-		"tiup", compVersion("tidb", version),
-		fmt.Sprintf("--binpath=%s", binPath),
+		"tiup", fmt.Sprintf("--binpath=%s", binPath),
+		compVersion("tidb", version),
 		"-P", strconv.Itoa(inst.Port),
 		"--store=tikv",
 		fmt.Sprintf("--host=%s", inst.Host),

--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -50,7 +50,7 @@ func NewTiKVInstance(dir, host string, id int, pds []*PDInstance) *TiKVInstance 
 }
 
 // Start calls set inst.cmd and Start
-func (inst *TiKVInstance) Start(ctx context.Context, version repository.Version) error {
+func (inst *TiKVInstance) Start(ctx context.Context, version repository.Version, binPath string) error {
 	if err := os.MkdirAll(inst.Dir, 0755); err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func (inst *TiKVInstance) Start(ctx context.Context, version repository.Version)
 		endpoints = append(endpoints, fmt.Sprintf("http://%s:%d", inst.Host, pd.StatusPort))
 	}
 	inst.cmd = exec.CommandContext(ctx,
-		"tiup", compVersion("tikv", version),
+		"tiup", specifyBinary("tikv", version, binPath),
 		fmt.Sprintf("--addr=%s:%d", inst.Host, inst.Port),
 		fmt.Sprintf("--status-addr=%s:%d", inst.Host, inst.StatusPort),
 		fmt.Sprintf("--pd=%s", strings.Join(endpoints, ",")),

--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -69,7 +69,8 @@ func (inst *TiKVInstance) Start(ctx context.Context, version repository.Version,
 		endpoints = append(endpoints, fmt.Sprintf("http://%s:%d", inst.Host, pd.StatusPort))
 	}
 	inst.cmd = exec.CommandContext(ctx,
-		"tiup", specifyBinary("tikv", version, binPath),
+		"tiup", compVersion("tikv", version),
+		fmt.Sprintf("--binpath=%s", binPath),
 		fmt.Sprintf("--addr=%s:%d", inst.Host, inst.Port),
 		fmt.Sprintf("--status-addr=%s:%d", inst.Host, inst.StatusPort),
 		fmt.Sprintf("--pd=%s", strings.Join(endpoints, ",")),

--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -69,8 +69,8 @@ func (inst *TiKVInstance) Start(ctx context.Context, version repository.Version,
 		endpoints = append(endpoints, fmt.Sprintf("http://%s:%d", inst.Host, pd.StatusPort))
 	}
 	inst.cmd = exec.CommandContext(ctx,
-		"tiup", compVersion("tikv", version),
-		fmt.Sprintf("--binpath=%s", binPath),
+		"tiup", fmt.Sprintf("--binpath=%s", binPath),
+		compVersion("tikv", version),
 		fmt.Sprintf("--addr=%s:%d", inst.Host, inst.Port),
 		fmt.Sprintf("--status-addr=%s:%d", inst.Host, inst.StatusPort),
 		fmt.Sprintf("--pd=%s", strings.Join(endpoints, ",")),

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -86,8 +86,7 @@ Examples:
   $ tiup playground nightly                         # Start a TiDB nightly version local cluster
   $ tiup playground v3.0.10 --db 3 --pd 3 --kv 3    # Start a local cluster with 10 nodes
   $ tiup playground nightly --monitor               # Start a local cluster with monitor system
-  $ tiup playground --db.binpath /xx/tidb-server --pd.binpath /xx/pd-server --kv.binpath /xx/tikv-server
-													# Start a local cluster with component binary path`,
+  $ tiup playground --db.binpath /xx/tidb-server    # Start a local cluster with component binary path`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			version := ""
@@ -156,7 +155,7 @@ func hasDashboard(pdAddr string) bool {
 }
 
 func getAbsolutePath(binPath string) string {
-	if !strings.HasPrefix(binPath, "/") {
+	if !strings.HasPrefix(binPath, "/") && !strings.HasPrefix(binPath, "~") {
 		binPath = filepath.Join(os.Getenv(localdata.EnvNameWorkDir), binPath)
 	}
 	return binPath

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -155,6 +155,13 @@ func hasDashboard(pdAddr string) bool {
 	return false
 }
 
+func getAbsolutePath(binPath string) string {
+	if !strings.HasPrefix(binPath, "/") {
+		binPath = filepath.Join(os.Getenv(localdata.EnvNameWorkDir), binPath)
+	}
+	return binPath
+}
+
 func bootCluster(version string, pdNum, tidbNum, tikvNum int, host string, monitor bool, tidbBinPath, tikvBinPath, pdBinPath string) error {
 	if pdNum < 1 || tidbNum < 1 || tikvNum < 1 {
 		return fmt.Errorf("all components count must be great than 0 (tidb=%v, tikv=%v, pd=%v)",
@@ -163,13 +170,13 @@ func bootCluster(version string, pdNum, tidbNum, tikvNum int, host string, monit
 
 	var pathMap = make(map[string]string)
 	if tidbBinPath != "" {
-		pathMap["tidb"] = tidbBinPath
+		pathMap["tidb"] = getAbsolutePath(tidbBinPath)
 	}
 	if tikvBinPath != "" {
-		pathMap["tikv"] = tikvBinPath
+		pathMap["tikv"] = getAbsolutePath(tikvBinPath)
 	}
 	if pdBinPath != "" {
-		pathMap["pd"] = pdBinPath
+		pathMap["pd"] = getAbsolutePath(pdBinPath)
 	}
 
 	// Initialize the profile

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -104,19 +104,6 @@ func LocalRoot() string {
 	return profile.Root()
 }
 
-// ParseBinary parses component part from <component>:<version>:<binpath> specification
-func ParseBinary(spec string) (string, repository.Version, string) {
-	if strings.Contains(spec, ":") {
-		parts := strings.Split(spec, ":")
-		var binPath = ""
-		if len(parts) == 3 {
-			binPath = parts[2]
-		}
-		return parts[0], repository.Version(parts[1]), binPath
-	}
-	return spec, "", ""
-}
-
 // ParseCompVersion parses component part from <component>[:version] specification
 func ParseCompVersion(spec string) (string, repository.Version) {
 	if strings.Contains(spec, ":") {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -104,6 +104,19 @@ func LocalRoot() string {
 	return profile.Root()
 }
 
+// ParseBinary parses component part from <component>:<version>:<binpath> specification
+func ParseBinary(spec string) (string, repository.Version, string) {
+	if strings.Contains(spec, ":") {
+		parts := strings.Split(spec, ":")
+		var binPath = ""
+		if len(parts) == 3 {
+			binPath = parts[2]
+		}
+		return parts[0], repository.Version(parts[1]), binPath
+	}
+	return spec, "", ""
+}
+
 // ParseCompVersion parses component part from <component>[:version] specification
 func ParseCompVersion(spec string) (string, repository.Version) {
 	if strings.Contains(spec, ":") {

--- a/tests/expected/tiup/tiup-h.output
+++ b/tests/expected/tiup/tiup-h.output
@@ -33,6 +33,7 @@ Available Components:
 Flags:
   -B, --binary <component>[:version]   Print binary path of a specific version of a component <component>[:version]
                                        and the latest version installed will be selected if no version specified
+      --binpath string                 Specify the binary path of component instance
   -h, --help                           help for tiup
       --rm                             Remove the data directory when the component instance finishes its run
       --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string

--- a/tests/expected/tiup/tiup-help.output
+++ b/tests/expected/tiup/tiup-help.output
@@ -33,6 +33,7 @@ Available Components:
 Flags:
   -B, --binary <component>[:version]   Print binary path of a specific version of a component <component>[:version]
                                        and the latest version installed will be selected if no version specified
+      --binpath string                 Specify the binary path of component instance
   -h, --help                           help for tiup
       --rm                             Remove the data directory when the component instance finishes its run
       --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string

--- a/tests/expected/tiup/tiup.output
+++ b/tests/expected/tiup/tiup.output
@@ -33,6 +33,7 @@ Available Components:
 Flags:
   -B, --binary <component>[:version]   Print binary path of a specific version of a component <component>[:version]
                                        and the latest version installed will be selected if no version specified
+      --binpath string                 Specify the binary path of component instance
   -h, --help                           help for tiup
       --rm                             Remove the data directory when the component instance finishes its run
       --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string


### PR DESCRIPTION
UCP https://github.com/pingcap-incubator/tiup/issues/77

### What problem does this PR solve? 

Support specifies the binary path when running a component.

### What is changed and how it works?

it runs like `tiup playground --kv 3 --db 3 --pd 3 --db.binpath /xx/tidb-server --kv.binpath /xx/tikv-server --pd.binpath /xx/pd-server`

Tests <!-- At least one of them must be included. -->

 - Manual test 




