### PR TITLE
cmd: clean temporary data in default

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Flags:
   -B, --binary <component>[:version]   Print binary path of a specific version of a component <component>[:version]
                                        and the latest version installed will be selected if no version specified
   -h, --help                           help for tiup
-      --rm                             Remove the data directory when the component instance finishes its run
       --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string
   -T, --tag string                     Specify a tag for component instance
       --version                        version for tiup

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,6 @@ func init() {
 		binary   string
 		binPath  string
 		tag      string
-		rm       bool
 		repoOpts repository.Options
 	)
 
@@ -84,7 +83,7 @@ the latest stable version will be downloaded from the repository.
 						break
 					}
 				}
-				return runComponent(tag, componentSpec, binPath, transparentParams, rm)
+				return runComponent(tag, componentSpec, binPath, transparentParams)
 			}
 			return cmd.Help()
 		},
@@ -101,7 +100,6 @@ the latest stable version will be downloaded from the repository.
 	rootCmd.Flags().StringVarP(&binary, "binary", "B", "", "Print binary path of a specific version of a component `<component>[:version]`\n"+
 		"and the latest version installed will be selected if no version specified")
 	rootCmd.Flags().StringVarP(&tag, "tag", "T", "", "Specify a tag for component instance")
-	rootCmd.Flags().BoolVar(&rm, "rm", false, "Remove the data directory when the component instance finishes its run")
 	rootCmd.Flags().StringVar(&binPath, "binpath", "", "Specify the binary path of component instance")
 
 	rootCmd.AddCommand(

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -64,6 +64,10 @@
         "path": "tiup/tiup-run-test2.output"
     },
     {
+        "command": "tiup test",
+        "path": "tiup/tiup-run-test3.output"
+    },
+    {
         "command": "tiup status",
         "path": ""
     },

--- a/tests/expected/tiup/tiup-h.output
+++ b/tests/expected/tiup/tiup-h.output
@@ -35,7 +35,6 @@ Flags:
                                        and the latest version installed will be selected if no version specified
       --binpath string                 Specify the binary path of component instance
   -h, --help                           help for tiup
-      --rm                             Remove the data directory when the component instance finishes its run
       --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string
   -T, --tag string                     Specify a tag for component instance
       --version                        version for tiup

--- a/tests/expected/tiup/tiup-help.output
+++ b/tests/expected/tiup/tiup-help.output
@@ -35,7 +35,6 @@ Flags:
                                        and the latest version installed will be selected if no version specified
       --binpath string                 Specify the binary path of component instance
   -h, --help                           help for tiup
-      --rm                             Remove the data directory when the component instance finishes its run
       --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string
   -T, --tag string                     Specify a tag for component instance
 

--- a/tests/expected/tiup/tiup-run-test3.output
+++ b/tests/expected/tiup/tiup-run-test3.output
@@ -1,0 +1,2 @@
+Starting TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin 
+integration test v1.1.1

--- a/tests/expected/tiup/tiup.output
+++ b/tests/expected/tiup/tiup.output
@@ -35,7 +35,6 @@ Flags:
                                        and the latest version installed will be selected if no version specified
       --binpath string                 Specify the binary path of component instance
   -h, --help                           help for tiup
-      --rm                             Remove the data directory when the component instance finishes its run
       --skip-version-check             Skip the strict version check, by default a version must be a valid SemVer string
   -T, --tag string                     Specify a tag for component instance
       --version                        version for tiup


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Clean temporary data directory after instance terminated if the `TAG` doesn't specify.
