### PR TITLE
Prevent tikv config from being overwritten and  Gracefully stop

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -64,15 +64,23 @@ func runComponent(tag, spec, binPath string, args []string) error {
 	}
 
 	ch := make(chan error)
+	defer func() {
+		for err := range ch {
+			if err != nil {
+				fmt.Printf("Failed to stop component `%s`: %s\n", component, err.Error())
+				return
+			}
+		}
+		fmt.Printf("Success to stop component `%s`\n", component)
+	}()
 	go func() {
 		defer close(ch)
-
-		fmt.Printf("Starting %s %s\n", p.Exec, strings.Join(p.Args, " "))
+		fmt.Printf("Starting component `%s`: %s %s\n", component, p.Exec, strings.Join(p.Args, " "))
 		ch <- p.cmd.Wait()
 	}()
 
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGKILL, syscall.SIGTERM, syscall.SIGQUIT)
+	signal.Notify(sig, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 	select {
 	case s := <-sig:

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -21,8 +21,10 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/fatih/color"
@@ -282,6 +284,7 @@ func bootCluster(options *bootOptions) error {
 	fmt.Println("Playground Bootstrapping...")
 
 	var monitorAddr string
+	var monitorCmd *exec.Cmd
 	if options.monitor {
 		if err := installIfMissing(profile, "prometheus", ""); err != nil {
 			return err
@@ -304,6 +307,7 @@ func bootCluster(options *bootOptions) error {
 		}
 
 		monitorAddr = addr
+		monitorCmd = cmd
 		go func() {
 			log, err := os.OpenFile(filepath.Join(promDir, "prom.log"), os.O_WRONLY|os.O_APPEND|os.O_CREATE, os.ModePerm)
 			if err != nil {
@@ -318,9 +322,6 @@ func bootCluster(options *bootOptions) error {
 			if err := cmd.Start(); err != nil {
 				fmt.Println("Monitor system start failed", err)
 				return
-			}
-			if err := cmd.Wait(); err != nil {
-				fmt.Println("Monitor system wait failed", err)
 			}
 		}()
 	}
@@ -367,11 +368,34 @@ func bootCluster(options *bootOptions) error {
 
 	dumpDSN(dbs)
 
+	go func() {
+		sc := make(chan os.Signal, 1)
+		signal.Notify(sc,
+			syscall.SIGHUP,
+			syscall.SIGINT,
+			syscall.SIGTERM,
+			syscall.SIGQUIT)
+		sig := (<-sc).(syscall.Signal)
+		for _, inst := range all {
+			_ = syscall.Kill(inst.Pid(), sig)
+		}
+		if monitorCmd != nil {
+			_ = syscall.Kill(monitorCmd.Process.Pid, sig)
+		}
+	}()
+
 	for _, inst := range all {
 		if err := inst.Wait(); err != nil {
 			return err
 		}
 	}
+
+	if monitorCmd != nil {
+		if err := monitorCmd.Wait(); err != nil {
+			fmt.Println("Monitor system wait failed", err)
+		}
+	}
+
 	return nil
 }
 

--- a/tests/expected/tiup/tiup-run-test-flag.output
+++ b/tests/expected/tiup/tiup-run-test-flag.output
@@ -1,2 +1,3 @@
-Starting TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin --flag value --flag2 values
+Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin --flag value --flag2 values
 integration test v1.1.1
+Success to stop component `test`

--- a/tests/expected/tiup/tiup-run-test-v1.1.1.output
+++ b/tests/expected/tiup/tiup-run-test-v1.1.1.output
@@ -1,2 +1,3 @@
-Starting TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin 
+Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin 
 integration test v1.1.1
+Success to stop component `test`

--- a/tests/expected/tiup/tiup-run-test.output
+++ b/tests/expected/tiup/tiup-run-test.output
@@ -1,2 +1,3 @@
-Starting TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.2/test.bin 
+Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.2/test.bin 
 integration test v1.1.2
+Success to stop component `test`

--- a/tests/expected/tiup/tiup-run-test2.output
+++ b/tests/expected/tiup/tiup-run-test2.output
@@ -1,2 +1,3 @@
-Starting TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin 
+Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin 
 integration test v1.1.1
+Success to stop component `test`

--- a/tests/expected/tiup/tiup-run-test3.output
+++ b/tests/expected/tiup/tiup-run-test3.output
@@ -1,2 +1,3 @@
-Starting TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin 
+Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin 
 integration test v1.1.1
+Success to stop component `test`


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

* #106 
* #108

### What is changed and how it works?

* Prevent tikv config from being overwritten
* Gracefully stop `tiup run`
* Process the signal in `playground`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

* Manual test (add detailed scripts or steps below)

1. sh run.sh
```bash
nohup tiup playground nightly --kv.config=./tikv.toml --db=1 --pd=1 --kv=1 >tiup.log 2>&1 &
echo "$!" > tiup.pid
```
2. sh stop.sh
```bash
kill `cat tiup.pid`
rm -f tiup.pid
```