### PR TITLE
cmd: refine exit message

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -67,11 +67,10 @@ func runComponent(tag, spec, binPath string, args []string) error {
 	defer func() {
 		for err := range ch {
 			if err != nil {
-				fmt.Printf("Failed to stop component `%s`: %s\n", component, err.Error())
+				fmt.Printf("Component `%s` exit with error: %s\n", component, err.Error())
 				return
 			}
 		}
-		fmt.Printf("Success to stop component `%s`\n", component)
 	}()
 	go func() {
 		defer close(ch)
@@ -91,7 +90,7 @@ func runComponent(tag, spec, binPath string, args []string) error {
 		return syscall.Kill(p.Pid, s.(syscall.Signal))
 
 	case err := <-ch:
-		return errors.Annotatef(err, "start `%s` (wd:%s) failed", p.Exec, p.Dir)
+		return errors.Annotatef(err, "run `%s` (wd:%s) failed", p.Exec, p.Dir)
 	}
 }
 

--- a/tests/expected/tiup/tiup-run-test-flag.output
+++ b/tests/expected/tiup/tiup-run-test-flag.output
@@ -1,3 +1,2 @@
 Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin --flag value --flag2 values
 integration test v1.1.1
-Success to stop component `test`

--- a/tests/expected/tiup/tiup-run-test-v1.1.1.output
+++ b/tests/expected/tiup/tiup-run-test-v1.1.1.output
@@ -1,3 +1,2 @@
 Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin 
 integration test v1.1.1
-Success to stop component `test`

--- a/tests/expected/tiup/tiup-run-test.output
+++ b/tests/expected/tiup/tiup-run-test.output
@@ -1,3 +1,2 @@
 Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.2/test.bin 
 integration test v1.1.2
-Success to stop component `test`

--- a/tests/expected/tiup/tiup-run-test2.output
+++ b/tests/expected/tiup/tiup-run-test2.output
@@ -1,3 +1,2 @@
 Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin 
 integration test v1.1.1
-Success to stop component `test`

--- a/tests/expected/tiup/tiup-run-test3.output
+++ b/tests/expected/tiup/tiup-run-test3.output
@@ -1,3 +1,2 @@
 Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin 
 integration test v1.1.1
-Success to stop component `test`


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

Exit message is redundant and misleading:
```
$ tiup cluster start example
...
Started cluster `example` successfully
Success to stop component `cluster`
```

One can easily misinterprets the message as "success to stop cluster".

### What is changed and how it works?

Only print error messages.
