### PR TITLE
bench: adjust tpcc prepare flags

### DIFF
--- a/components/bench/tpcc.go
+++ b/components/bench/tpcc.go
@@ -48,9 +48,6 @@ func registerTpcc(root *cobra.Command) {
 	cmd.PersistentFlags().IntVar(&tpccConfig.Parts, "parts", 1, "Number to partition warehouses")
 	cmd.PersistentFlags().IntVar(&tpccConfig.Warehouses, "warehouses", 10, "Number of warehouses")
 	cmd.PersistentFlags().BoolVar(&tpccConfig.CheckAll, "check-all", false, "Run all consistency checks")
-	cmd.PersistentFlags().StringVar(&tpccConfig.OutputDir, "output", "", "Output directory for generating csv file when preparing data")
-	cmd.PersistentFlags().StringVar(&tpccConfig.SpecifiedTables, "tables", "", "Specified tables for "+
-		"generating file, separated by ','. Valid only if output is set. If this flag is not set, generate all tables by default.")
 
 	var cmdPrepare = &cobra.Command{
 		Use:   "prepare",
@@ -59,6 +56,9 @@ func registerTpcc(root *cobra.Command) {
 			executeTpcc("prepare")
 		},
 	}
+	cmdPrepare.PersistentFlags().StringVar(&tpccConfig.OutputDir, "output", "", "Output directory for generating file if specified")
+	cmdPrepare.PersistentFlags().StringVar(&tpccConfig.SpecifiedTables, "tables", "", "Specified tables for "+
+		"generating file, separated by ','. Valid only if output is set. If this flag is not set, generate all tables by default")
 
 	var cmdRun = &cobra.Command{
 		Use:   "run",


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The output and tables should be placed inside the prepare subcommand.

### What is changed and how it works?

```
Usage:
  ./bench tpcc prepare [flags]

Flags:
  -h, --help            help for prepare
      --output string   Output directory for generating file if specified
      --tables string   Specified tables for generating file, separated by ','. Valid only if output is set. If this flag is not set, generate all tables by default
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

```
 Manual
```

Code changes

```
None
```

Side effects

```
None
```

Related changes

```
None
```