### PR TITLE
cmd: refine exit message

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -86,8 +86,11 @@ func runComponent(tag, spec, binPath string, args []string) error {
 		fmt.Printf("Got signal %v (Component: %v ; PID: %v)\n", s, component, p.Pid)
 		if component == "tidb" {
 			return syscall.Kill(p.Pid, syscall.SIGKILL)
+		} else if s.(syscall.Signal) != syscall.SIGINT {
+			return syscall.Kill(p.Pid, s.(syscall.Signal))
+		} else {
+			return nil
 		}
-		return syscall.Kill(p.Pid, s.(syscall.Signal))
 
 	case err := <-ch:
 		return errors.Annotatef(err, "run `%s` (wd:%s) failed", p.Exec, p.Dir)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -66,7 +66,7 @@ func runComponent(tag, spec, binPath string, args []string) error {
 	ch := make(chan error)
 	defer func() {
 		for err := range ch {
-			if err != nil {
+			if err != nil && !strings.Contains(err.Error(), "signal") {
 				fmt.Printf("Component `%s` exit with error: %s\n", component, err.Error())
 				return
 			}

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -388,11 +388,13 @@ func bootCluster(options *bootOptions) error {
 			syscall.SIGTERM,
 			syscall.SIGQUIT)
 		sig := (<-sc).(syscall.Signal)
-		for _, inst := range all {
-			_ = syscall.Kill(inst.Pid(), sig)
-		}
-		if monitorCmd != nil {
-			_ = syscall.Kill(monitorCmd.Process.Pid, sig)
+		if sig != syscall.SIGINT {
+			for _, inst := range all {
+				_ = syscall.Kill(inst.Pid(), sig)
+			}
+			if monitorCmd != nil {
+				_ = syscall.Kill(monitorCmd.Process.Pid, sig)
+			}
 		}
 	}()
 


### PR DESCRIPTION
Signed-off-by: Zheng Xiangsheng <hundundm@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

* The exit due to signal should not be considered an error.
* After receiving multiple signals, TiKV will exit abnormally.

### What is changed and how it works?

* Determine whether the error at exit contains the `signal` keyword.
* SIGINT is not passed. It will be sent to all subprocesses by the terminal.