### PR TITLE
Fix TiFlash cluster manager path

### DIFF
--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -97,7 +97,7 @@ func (inst *TiFlashInstance) Start(ctx context.Context, version repository.Versi
 		binPath = dir
 	}
 	// Wait for PD
-	time.Sleep(30 * time.Second)
+	time.Sleep(10 * time.Second)
 	dirPath := path.Dir(binPath)
 	clusterManagerPath := getFlashClusterPath(dirPath)
 	if err := inst.checkConfig(wd, clusterManagerPath, tidbStatusAddrs, endpoints); err != nil {

--- a/components/playground/instance/tiflash_config.go
+++ b/components/playground/instance/tiflash_config.go
@@ -36,7 +36,7 @@ runAsDaemon = true
 service_addr = "%[10]s:%[8]d"
 tidb_status_addr = "%[11]s"
 [flash.flash_cluster]
-cluster_manager_path = "%[4]s"
+cluster_manager_path = "%[12]s"
 log = "%[7]s/tiflash_cluster_manager.log"
 master_ttl = 60
 refresh_interval = 20
@@ -90,14 +90,14 @@ quota = "default"
 ip = "::/0"
 `
 
-func writeTiFlashConfig(w io.Writer, tcpPort, httpPort, servicePort, metricsPort int, ip, deployDir string, tidbStatusAddrs, endpoints []string) error {
+func writeTiFlashConfig(w io.Writer, tcpPort, httpPort, servicePort, metricsPort int, ip, deployDir, clusterManagerPath string, tidbStatusAddrs, endpoints []string) error {
 	pdAddrs := strings.Join(endpoints, ",")
 	dataDir := fmt.Sprintf("%s/data", deployDir)
 	tmpDir := fmt.Sprintf("%s/tmp", deployDir)
 	logDir := fmt.Sprintf("%s/log", deployDir)
 	conf := fmt.Sprintf(tiflashConfig, pdAddrs, httpPort, tcpPort,
 		deployDir, dataDir, tmpDir, logDir, servicePort, metricsPort,
-		ip, strings.Join(tidbStatusAddrs, ","))
+		ip, strings.Join(tidbStatusAddrs, ","), clusterManagerPath)
 	_, err := w.Write([]byte(conf))
 	return err
 }

--- a/pkg/utils/ioutil.go
+++ b/pkg/utils/ioutil.go
@@ -16,7 +16,6 @@ package utils
 import (
 	"archive/tar"
 	"compress/gzip"
-	"fmt"
 	"io"
 	"os"
 	"path"
@@ -35,29 +34,6 @@ func IsExist(path string) bool {
 func IsNotExist(path string) bool {
 	_, err := os.Stat(path)
 	return os.IsNotExist(err)
-}
-
-// CopyFile copies a file from src to dst
-func CopyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	if _, err := os.Stat(dst); !os.IsNotExist(err) {
-		return fmt.Errorf("destination path %s already exist", dst)
-	}
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	if _, err = io.Copy(out, in); err != nil {
-		return err
-	}
-	return nil
 }
 
 // Untar decompresses the tarball


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cluster manager should be a directory rather than a binary.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch
