### PR TITLE
Refactoring for better testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,5 +118,7 @@ package: playground client pack tiops
 fmt:
 	@echo "gofmt (simplify)"
 	@gofmt -s -l -w $(FILES) 2>&1
+	@echo "goimports (if installed)"
+	$(shell gimports -w $(FILES) 2>/dev/null)
 
 .PHONY: cmd package

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCleanCmd() *cobra.Command {
+func newCleanCmd(env *meta.Environment) *cobra.Command {
 	var all bool
 	cmd := &cobra.Command{
 		Use:   "clean",
@@ -36,15 +36,15 @@ func newCleanCmd() *cobra.Command {
 			if len(args) == 0 && !all {
 				return cmd.Help()
 			}
-			return cleanData(args, all)
+			return cleanData(env, args, all)
 		},
 	}
 	cmd.Flags().BoolVar(&all, "all", false, "Clean all data of instantiated components")
 	return cmd
 }
 
-func cleanData(names []string, all bool) error {
-	dataDir := meta.LocalPath(localdata.DataParentDir)
+func cleanData(env *meta.Environment, names []string, all bool) error {
+	dataDir := env.LocalPath(localdata.DataParentDir)
 	if utils.IsNotExist(dataDir) {
 		return nil
 	}
@@ -62,7 +62,7 @@ func cleanData(names []string, all bool) error {
 		}
 		metaFile := filepath.Join(localdata.DataParentDir, dir.Name(), localdata.MetaFilename)
 		var process process
-		err := meta.Profile().ReadJSON(metaFile, &process)
+		err := env.Profile().ReadJSON(metaFile, &process)
 		if err != nil {
 			return err
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newInstallCmd() *cobra.Command {
+func newInstallCmd(env *meta.Environment) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install <component1>[:version] [component2...N]",
 		Short: "Install a specific version of a component",
@@ -38,14 +38,14 @@ of the same component:
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			return installComponents(args)
+			return installComponents(env, args)
 		},
 	}
 	return cmd
 }
 
-func installComponents(specs []string) error {
-	manifest, err := meta.LatestManifest()
+func installComponents(env *meta.Environment, specs []string) error {
+	manifest, err := env.LatestManifest()
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func installComponents(specs []string) error {
 			return fmt.Errorf("component `%s` does not support `%s/%s`", component, runtime.GOOS, runtime.GOARCH)
 		}
 
-		err := meta.DownloadComponent(component, version, version.IsNightly())
+		err := env.DownloadComponent(component, version, version.IsNightly())
 		if err != nil {
 			return err
 		}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newListCmd() *cobra.Command {
+func newListCmd(env *meta.Environment) *cobra.Command {
 	var (
 		showInstalled bool
 		refresh       bool
@@ -50,11 +50,11 @@ components or versions which have not been installed.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch len(args) {
 			case 0:
-				result, err := showComponentList(showInstalled, refresh)
+				result, err := showComponentList(env, showInstalled, refresh)
 				result.print()
 				return err
 			case 1:
-				result, err := showComponentVersions(args[0], showInstalled, refresh)
+				result, err := showComponentVersions(env, args[0], showInstalled, refresh)
 				result.print()
 				return err
 			default:
@@ -78,23 +78,23 @@ func (lr *listResult) print() {
 	tui.PrintTable(lr.cmpTable, true)
 }
 
-func showComponentList(onlyInstalled bool, refresh bool) (*listResult, error) {
-	if refresh || meta.Profile().Manifest() == nil {
-		manifest, err := meta.Repository().Manifest()
+func showComponentList(env *meta.Environment, onlyInstalled bool, refresh bool) (*listResult, error) {
+	if refresh || env.Profile().Manifest() == nil {
+		manifest, err := env.Repository().Manifest()
 		if err != nil {
 			return nil, err
 		}
-		err = meta.Profile().SaveManifest(manifest)
+		err = env.Profile().SaveManifest(manifest)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	installed, err := meta.Profile().InstalledComponents()
+	installed, err := env.Profile().InstalledComponents()
 	if err != nil {
 		return nil, err
 	}
-	manifest := meta.Profile().Manifest()
+	manifest := env.Profile().Manifest()
 	var cmpTable [][]string
 	cmpTable = append(cmpTable, []string{"Name", "Installed", "Platforms", "Description"})
 
@@ -108,7 +108,7 @@ func showComponentList(onlyInstalled bool, refresh bool) (*listResult, error) {
 		}
 		installStatus := ""
 		if localComponents.Exist(comp.Name) {
-			versions, err := meta.Profile().InstalledVersions(comp.Name)
+			versions, err := env.Profile().InstalledVersions(comp.Name)
 			if err != nil {
 				return nil, err
 			}
@@ -129,23 +129,23 @@ func showComponentList(onlyInstalled bool, refresh bool) (*listResult, error) {
 	}, nil
 }
 
-func showComponentVersions(component string, onlyInstalled bool, refresh bool) (*listResult, error) {
-	if refresh || meta.Profile().Versions(component) == nil {
-		manifest, err := meta.Repository().ComponentVersions(component)
+func showComponentVersions(env *meta.Environment, component string, onlyInstalled bool, refresh bool) (*listResult, error) {
+	if refresh || env.Profile().Versions(component) == nil {
+		manifest, err := env.Repository().ComponentVersions(component)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		err = meta.Profile().SaveVersions(component, manifest)
+		err = env.Profile().SaveVersions(component, manifest)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	versions, err := meta.Profile().InstalledVersions(component)
+	versions, err := env.Profile().InstalledVersions(component)
 	if err != nil {
 		return nil, err
 	}
-	manifest := meta.Profile().Versions(component)
+	manifest := env.Profile().Versions(component)
 
 	var cmpTable [][]string
 	cmpTable = append(cmpTable, []string{"Version", "Installed", "Release:", "Platforms"})

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -84,7 +84,6 @@ func runComponent(env *meta.Environment, tag, spec, binPath string, args []strin
 
 	go func() {
 		defer close(ch)
-		fmt.Printf("Starting component `%s`: %s %s\n", component, p.Exec, strings.Join(p.Args, " "))
 		ch <- p.cmd.Wait()
 	}()
 
@@ -237,6 +236,7 @@ func launchComponent(ctx context.Context, component string, version repository.V
 		cmd:         c,
 	}
 
+	fmt.Printf("Starting component `%s`: %s\n", component, strings.Join(append([]string{p.Exec}, p.Args...), " "))
 	err = p.cmd.Start()
 	if p.cmd.Process != nil {
 		p.Pid = p.cmd.Process.Pid

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -33,9 +33,9 @@ import (
 	"github.com/pingcap/errors"
 )
 
-func runComponent(tag, spec, binPath string, args []string) error {
+func runComponent(env *meta.Environment, tag, spec, binPath string, args []string) error {
 	component, version := meta.ParseCompVersion(spec)
-	if !isSupportedComponent(component) {
+	if !isSupportedComponent(env, component) {
 		return fmt.Errorf("component `%s` does not support `%s/%s` (see `tiup list --refresh`)", component, runtime.GOOS, runtime.GOARCH)
 	}
 
@@ -45,7 +45,7 @@ func runComponent(tag, spec, binPath string, args []string) error {
 	// Clean data if current instance is a temporary
 	clean := tag == "" && os.Getenv(localdata.EnvNameInstanceDataDir) == ""
 
-	p, err := launchComponent(ctx, component, version, binPath, tag, args)
+	p, err := launchComponent(ctx, component, version, binPath, tag, args, env)
 	// If the process has been launched, we must save the process info to meta directory
 	if err == nil || (p != nil && p.Pid != 0) {
 		defer cleanDataDir(clean, p.Dir)
@@ -114,19 +114,19 @@ func cleanDataDir(rm bool, dir string) {
 	}
 }
 
-func isSupportedComponent(component string) bool {
+func isSupportedComponent(env *meta.Environment, component string) bool {
 	// check local manifest
-	manifest := meta.Profile().Manifest()
+	manifest := env.Profile().Manifest()
 	if manifest != nil && manifest.HasComponent(component) {
 		return true
 	}
 
-	manifest, err := meta.Repository().Manifest()
+	manifest, err := env.Repository().Manifest()
 	if err != nil {
 		fmt.Println("Fetch latest manifest error:", err)
 		return false
 	}
-	if err := meta.Profile().SaveManifest(manifest); err != nil {
+	if err := env.Profile().SaveManifest(manifest); err != nil {
 		fmt.Println("Save latest manifest error:", err)
 	}
 	comp, found := manifest.FindComponent(component)
@@ -160,13 +160,14 @@ func base62Tag() string {
 	return string(b)
 }
 
-func launchComponent(ctx context.Context, component string, version repository.Version, binPath string, tag string, args []string) (*process, error) {
-	selectVer, err := meta.DownloadComponentIfMissing(component, version)
+func launchComponent(ctx context.Context, component string, version repository.Version, binPath string, tag string, args []string, env *meta.Environment) (*process, error) {
+	selectVer, err := env.DownloadComponentIfMissing(component, version)
 	if err != nil {
 		return nil, err
 	}
 
-	installPath, err := meta.ComponentInstalledDir(component, selectVer)
+	profile := env.Profile()
+	installPath, err := profile.ComponentInstalledPath(component, selectVer)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +179,7 @@ func launchComponent(ctx context.Context, component string, version repository.V
 		}
 		binPath = p
 	} else {
-		binPath, err = meta.BinaryPath(component, selectVer)
+		binPath, err = profile.BinaryPath(component, selectVer)
 		if err != nil {
 			return nil, err
 		}
@@ -190,13 +191,13 @@ func launchComponent(ctx context.Context, component string, version repository.V
 		if tag == "" {
 			tag = base62Tag()
 		}
-		wd = meta.LocalPath(localdata.DataParentDir, tag)
+		wd = env.LocalPath(localdata.DataParentDir, tag)
 	}
 	if err := os.MkdirAll(wd, 0755); err != nil {
 		return nil, err
 	}
 
-	sd := meta.LocalPath(localdata.StorageParentDir, component)
+	sd := env.LocalPath(localdata.StorageParentDir, component)
 	if err := os.MkdirAll(sd, 0755); err != nil {
 		return nil, err
 	}
@@ -207,7 +208,7 @@ func launchComponent(ctx context.Context, component string, version repository.V
 	}
 
 	envs := []string{
-		fmt.Sprintf("%s=%s", localdata.EnvNameHome, meta.LocalRoot()),
+		fmt.Sprintf("%s=%s", localdata.EnvNameHome, profile.Root()),
 		fmt.Sprintf("%s=%s", localdata.EnvNameWorkDir, tiupWd),
 		fmt.Sprintf("%s=%s", localdata.EnvNameInstanceDataDir, wd),
 		fmt.Sprintf("%s=%s", localdata.EnvNameComponentDataDir, sd),

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newStatusCmd() *cobra.Command {
+func newStatusCmd(env *meta.Environment) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "List the status of instantiated components",
@@ -36,16 +36,16 @@ func newStatusCmd() *cobra.Command {
 			if len(args) > 0 {
 				return cmd.Help()
 			}
-			return showStatus()
+			return showStatus(env)
 		},
 	}
 	return cmd
 }
 
-func showStatus() error {
+func showStatus(env *meta.Environment) error {
 	var table [][]string
 	table = append(table, []string{"Name", "Component", "PID", "Status", "Created Time", "Directory", "Binary", "Args"})
-	if dataDir := meta.LocalPath(localdata.DataParentDir); utils.IsExist(dataDir) {
+	if dataDir := env.LocalPath(localdata.DataParentDir); utils.IsExist(dataDir) {
 		dirs, err := ioutil.ReadDir(dataDir)
 		if err != nil {
 			return err
@@ -57,13 +57,13 @@ func showStatus() error {
 			metaFile := filepath.Join(localdata.DataParentDir, dir.Name(), localdata.MetaFilename)
 
 			// If the path doesn't contain the meta file, which means startup interrupted
-			if utils.IsNotExist(meta.LocalPath(metaFile)) {
-				_ = os.RemoveAll(meta.LocalPath(filepath.Join(localdata.DataParentDir, dir.Name())))
+			if utils.IsNotExist(env.LocalPath(metaFile)) {
+				_ = os.RemoveAll(env.LocalPath(filepath.Join(localdata.DataParentDir, dir.Name())))
 				continue
 			}
 
 			var process process
-			err := meta.Profile().ReadJSON(metaFile, &process)
+			err := env.Profile().ReadJSON(metaFile, &process)
 			if err != nil {
 				return err
 			}

--- a/components/playground/instance/instance.go
+++ b/components/playground/instance/instance.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pingcap-incubator/tiup/pkg/localdata"
+
 	"github.com/pingcap-incubator/tiup/pkg/repository"
 )
 
@@ -32,7 +34,7 @@ type instance struct {
 // Instance represent running component
 type Instance interface {
 	Pid() int
-	Start(ctx context.Context, version repository.Version, binPath string) error
+	Start(ctx context.Context, version repository.Version, binPath string, profile *localdata.Profile) error
 	Wait() error
 }
 

--- a/components/playground/instance/pd.go
+++ b/components/playground/instance/pd.go
@@ -56,7 +56,7 @@ func (inst *PDInstance) Join(pds []*PDInstance) *PDInstance {
 }
 
 // Start calls set inst.cmd and Start
-func (inst *PDInstance) Start(ctx context.Context, version repository.Version, binPath string) error {
+func (inst *PDInstance) Start(ctx context.Context, version repository.Version, binPath string, _ *localdata.Profile) error {
 	if err := os.MkdirAll(inst.Dir, 0755); err != nil {
 		return err
 	}

--- a/components/playground/instance/tidb.go
+++ b/components/playground/instance/tidb.go
@@ -50,7 +50,7 @@ func NewTiDBInstance(dir, host, configPath string, id int, pds []*PDInstance) *T
 }
 
 // Start calls set inst.cmd and Start
-func (inst *TiDBInstance) Start(ctx context.Context, version repository.Version, binPath string) error {
+func (inst *TiDBInstance) Start(ctx context.Context, version repository.Version, binPath string, _ *localdata.Profile) error {
 	if err := os.MkdirAll(inst.Dir, 0755); err != nil {
 		return err
 	}

--- a/components/playground/instance/tiflash.go
+++ b/components/playground/instance/tiflash.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/pingcap-incubator/tiup/pkg/localdata"
-	"github.com/pingcap-incubator/tiup/pkg/meta"
 	"github.com/pingcap-incubator/tiup/pkg/repository"
 	"github.com/pingcap-incubator/tiup/pkg/utils"
 	"github.com/pingcap/errors"
@@ -68,7 +67,7 @@ func getFlashClusterPath(dir string) string {
 }
 
 // Start calls set inst.cmd and Start
-func (inst *TiFlashInstance) Start(ctx context.Context, version repository.Version, binPath string) error {
+func (inst *TiFlashInstance) Start(ctx context.Context, version repository.Version, binPath string, profile *localdata.Profile) error {
 	if err := os.MkdirAll(inst.Dir, 0755); err != nil {
 		return err
 	}
@@ -86,11 +85,11 @@ func (inst *TiFlashInstance) Start(ctx context.Context, version repository.Versi
 	}
 
 	if binPath == "" {
-		installedVersion, err := meta.SelectInstalledVersion("tiflash", version)
+		installedVersion, err := profile.SelectInstalledVersion("tiflash", version)
 		if err != nil {
 			return err
 		}
-		dir, err := meta.BinaryPath("tiflash", installedVersion)
+		dir, err := profile.BinaryPath("tiflash", installedVersion)
 		if err != nil {
 			return err
 		}

--- a/components/playground/instance/tikv.go
+++ b/components/playground/instance/tikv.go
@@ -51,7 +51,7 @@ func NewTiKVInstance(dir, host, configPath string, id int, pds []*PDInstance) *T
 }
 
 // Start calls set inst.cmd and Start
-func (inst *TiKVInstance) Start(ctx context.Context, version repository.Version, binPath string) error {
+func (inst *TiKVInstance) Start(ctx context.Context, version repository.Version, binPath string, _ *localdata.Profile) error {
 	if err := os.MkdirAll(inst.Dir, 0755); err != nil {
 		return err
 	}

--- a/pkg/localdata/profile.go
+++ b/pkg/localdata/profile.go
@@ -19,12 +19,14 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/user"
 	"path/filepath"
 	"sort"
 
 	"github.com/pingcap-incubator/tiup/pkg/repository"
 	"github.com/pingcap-incubator/tiup/pkg/utils"
 	"github.com/pingcap/errors"
+	"golang.org/x/mod/semver"
 )
 
 // Profile represents the `tiup` profile
@@ -37,6 +39,24 @@ func NewProfile(root string) *Profile {
 	return &Profile{root: root}
 }
 
+// InitProfile creates a new profile using environment variables and defaults.
+func InitProfile() *Profile {
+	var profileDir string
+	switch {
+	case os.Getenv(EnvNameHome) != "":
+		profileDir = os.Getenv(EnvNameHome)
+	case DefaultTiupHome != "":
+		profileDir = DefaultTiupHome
+	default:
+		u, err := user.Current()
+		if err != nil {
+			panic("cannot get current user information: " + err.Error())
+		}
+		profileDir = filepath.Join(u.HomeDir, ProfileDirName)
+	}
+	return NewProfile(profileDir)
+}
+
 // Path returns a full path which is related to profile root directory
 func (p *Profile) Path(relpath string) string {
 	return filepath.Join(p.root, relpath)
@@ -45,6 +65,54 @@ func (p *Profile) Path(relpath string) string {
 // Root returns the root path of the `tiup`
 func (p *Profile) Root() string {
 	return p.root
+}
+
+// BinaryPath returns the binary path of component specific version
+func (p *Profile) BinaryPath(component string, version repository.Version) (string, error) {
+	manifest := p.Versions(component)
+	if manifest == nil {
+		return "", errors.Errorf("component `%s` doesn't install", component)
+	}
+	var entry string
+	if version.IsNightly() && manifest.Nightly != nil {
+		entry = manifest.Nightly.Entry
+	} else {
+		for _, v := range manifest.Versions {
+			if v.Version == version {
+				entry = v.Entry
+			}
+		}
+	}
+	if entry == "" {
+		return "", errors.Errorf("cannot found entry for %s:%s", component, version)
+	}
+	installPath, err := p.ComponentInstalledPath(component, version)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(installPath, entry), nil
+}
+
+// ComponentInstalledPath returns the path where the component installed
+func (p *Profile) ComponentInstalledPath(component string, version repository.Version) (string, error) {
+	versions, err := p.InstalledVersions(component)
+	if err != nil {
+		return "", err
+	}
+
+	// Use the latest version if user doesn't specify a specific version
+	// report an error if the specific component doesn't be installed
+
+	// Check whether the specific version exist in local
+	if version.IsEmpty() && len(versions) > 0 {
+		sort.Slice(versions, func(i, j int) bool {
+			return semver.Compare(versions[i], versions[j]) < 0
+		})
+		version = repository.Version(versions[len(versions)-1])
+	} else if version.IsEmpty() {
+		return "", fmt.Errorf("component not installed, please try `tiup install %s` to install it", component)
+	}
+	return filepath.Join(p.Path(ComponentParentDir), component, version.String()), nil
 }
 
 // SaveTo saves file to the profile directory, path is relative to the
@@ -178,4 +246,36 @@ func (p *Profile) InstalledVersions(component string) ([]string, error) {
 		versions = append(versions, fi.Name())
 	}
 	return versions, nil
+}
+
+// SelectInstalledVersion selects the installed versions and the latest release version
+// will be chosen if there is an empty version
+func (p *Profile) SelectInstalledVersion(component string, version repository.Version) (repository.Version, error) {
+	installed, err := p.InstalledVersions(component)
+	if err != nil {
+		return "", err
+	}
+
+	errInstallFirst := fmt.Errorf("use `tiup install %[1]s` to install `%[1]s` first", component)
+	if len(installed) < 1 {
+		return "", errInstallFirst
+	}
+
+	if version.IsEmpty() {
+		sort.Slice(installed, func(i, j int) bool {
+			return semver.Compare(installed[i], installed[j]) < 0
+		})
+		version = repository.Version(installed[len(installed)-1])
+	}
+	found := false
+	for _, v := range installed {
+		if repository.Version(v) == version {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return "", errInstallFirst
+	}
+	return version, nil
 }

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -16,42 +16,14 @@ package meta
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/pingcap-incubator/tiup/pkg/localdata"
 	"github.com/pingcap-incubator/tiup/pkg/repository"
-	"github.com/pingcap/errors"
 	"golang.org/x/mod/semver"
 )
-
-var (
-	// profile represents the TiUP local profile
-	profile *localdata.Profile
-	// repo represents the components repository of TiUP, it can be a
-	// local file system or a HTTP URL
-	repo *repository.Repository
-)
-
-func init() {
-	// Initialize the global profile
-	var profileDir string
-	switch {
-	case os.Getenv(localdata.EnvNameHome) != "":
-		profileDir = os.Getenv(localdata.EnvNameHome)
-	case localdata.DefaultTiupHome != "":
-		profileDir = localdata.DefaultTiupHome
-	default:
-		u, err := user.Current()
-		if err != nil {
-			panic("cannot get current user information: " + err.Error())
-		}
-		profileDir = filepath.Join(u.HomeDir, localdata.ProfileDirName)
-	}
-	profile = localdata.NewProfile(profileDir)
-}
 
 // Mirror return mirror of tiup.
 // If it's not defined, it will use "https://tiup-mirrors.pingcap.com/".
@@ -62,110 +34,63 @@ func Mirror() string {
 	return repository.DefaultMirror
 }
 
-// InitRepository initialize the repository
-func InitRepository(options repository.Options) error {
+// Environment is the user's fundamental configuration including local and remote parts.
+type Environment struct {
+	// profile represents the TiUP local profile
+	profile *localdata.Profile
+	// repo represents the components repository of TiUP, it can be a
+	// local file system or a HTTP URL
+	repo *repository.Repository
+}
+
+// InitEnv creates a new Environment object configured using env vars and defaults.
+func InitEnv(options repository.Options) (*Environment, error) {
+	profile := localdata.InitProfile()
+
 	// Initialize the repository
 	// Replace the mirror if some sub-commands use different mirror address
 	mirror := repository.NewMirror(Mirror(), repository.MirrorOptions{})
-	r, err := repository.NewRepository(mirror, options)
-	repo = r
-	return err
+	repo, err := repository.NewRepository(mirror, options)
+	return &Environment{profile, repo}, err
+}
+
+// New creates a new Environment with the provided data.
+func New(profile *localdata.Profile, repo *repository.Repository) *Environment {
+	return &Environment{profile, repo}
 }
 
 // Repository returns the initialized repository
-func Repository() *repository.Repository {
-	return repo
+func (env *Environment) Repository() *repository.Repository {
+	return env.repo
 }
 
 // SetRepository exports for test
-func SetRepository(r *repository.Repository) {
-	repo = r
+func (env *Environment) SetRepository(r *repository.Repository) {
+	env.repo = r
 }
 
 // Profile returns the profile of local data
-func Profile() *localdata.Profile {
-	return profile
+func (env *Environment) Profile() *localdata.Profile {
+	return env.profile
 }
 
 // SetProfile exports for test
-func SetProfile(p *localdata.Profile) {
-	profile = p
+func (env *Environment) SetProfile(p *localdata.Profile) {
+	env.profile = p
 }
 
 // LocalPath returns the local path absolute path
-func LocalPath(path ...string) string {
-	return profile.Path(filepath.Join(path...))
-}
-
-// LocalRoot returns the root path of profile
-func LocalRoot() string {
-	return profile.Root()
-}
-
-// ParseCompVersion parses component part from <component>[:version] specification
-func ParseCompVersion(spec string) (string, repository.Version) {
-	if strings.Contains(spec, ":") {
-		parts := strings.SplitN(spec, ":", 2)
-		return parts[0], repository.Version(parts[1])
-	}
-	return spec, ""
-}
-
-// BinaryPath returns the binary path of component specific version
-func BinaryPath(component string, version repository.Version) (string, error) {
-	manifest := profile.Versions(component)
-	if manifest == nil {
-		return "", errors.Errorf("component `%s` doesn't install", component)
-	}
-	var entry string
-	if version.IsNightly() && manifest.Nightly != nil {
-		entry = manifest.Nightly.Entry
-	} else {
-		for _, v := range manifest.Versions {
-			if v.Version == version {
-				entry = v.Entry
-			}
-		}
-	}
-	if entry == "" {
-		return "", errors.Errorf("cannot found entry for %s:%s", component, version)
-	}
-	installPath, err := ComponentInstalledDir(component, version)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(installPath, entry), nil
-}
-
-// ComponentInstalledDir returns the path where the component installed
-func ComponentInstalledDir(component string, version repository.Version) (string, error) {
-	versions, err := profile.InstalledVersions(component)
-	if err != nil {
-		return "", err
-	}
-
-	// Use the latest version if user doesn't specify a specific version
-	// report an error if the specific component doesn't be installed
-
-	// Check whether the specific version exist in local
-	if version.IsEmpty() && len(versions) > 0 {
-		sort.Slice(versions, func(i, j int) bool {
-			return semver.Compare(versions[i], versions[j]) < 0
-		})
-		version = repository.Version(versions[len(versions)-1])
-	} else if version.IsEmpty() {
-		return "", fmt.Errorf("component not installed, please try `tiup install %s` to install it", component)
-	}
-	return filepath.Join(LocalPath(localdata.ComponentParentDir), component, version.String()), nil
+func (env *Environment) LocalPath(path ...string) string {
+	return env.profile.Path(filepath.Join(path...))
 }
 
 // DownloadComponent downloads the specific version of a component from repository
-func DownloadComponent(component string, version repository.Version, overwrite bool) error {
-	versions, err := repo.ComponentVersions(component)
+func (env *Environment) DownloadComponent(component string, version repository.Version, overwrite bool) error {
+	versions, err := env.repo.ComponentVersions(component)
 	if err != nil {
 		return err
 	}
-	err = profile.SaveVersions(component, versions)
+	err = env.profile.SaveVersions(component, versions)
 	if err != nil {
 		return err
 	}
@@ -178,7 +103,7 @@ func DownloadComponent(component string, version repository.Version, overwrite b
 	}
 	if !overwrite {
 		// Ignore if installed
-		installed, err := profile.InstalledVersions(component)
+		installed, err := env.profile.InstalledVersions(component)
 		if err != nil {
 			return err
 		}
@@ -195,44 +120,18 @@ func DownloadComponent(component string, version repository.Version, overwrite b
 		}
 	}
 
-	return repo.DownloadComponent(LocalPath(localdata.ComponentParentDir), component, version)
+	return env.repo.DownloadComponent(env.LocalPath(localdata.ComponentParentDir), component, version)
 }
 
 // SelectInstalledVersion selects the installed versions and the latest release version
 // will be chosen if there is an empty version
-func SelectInstalledVersion(component string, version repository.Version) (repository.Version, error) {
-	installed, err := profile.InstalledVersions(component)
-	if err != nil {
-		return "", err
-	}
-
-	errInstallFirst := fmt.Errorf("use `tiup install %[1]s` to install `%[1]s` first", component)
-	if len(installed) < 1 {
-		return "", errInstallFirst
-	}
-
-	if version.IsEmpty() {
-		sort.Slice(installed, func(i, j int) bool {
-			return semver.Compare(installed[i], installed[j]) < 0
-		})
-		version = repository.Version(installed[len(installed)-1])
-	}
-	found := false
-	for _, v := range installed {
-		if repository.Version(v) == version {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return "", errInstallFirst
-	}
-	return version, nil
+func (env *Environment) SelectInstalledVersion(component string, version repository.Version) (repository.Version, error) {
+	return env.profile.SelectInstalledVersion(component, version)
 }
 
 // DownloadComponentIfMissing downloads the specific version of a component if it is missing
-func DownloadComponentIfMissing(component string, version repository.Version) (repository.Version, error) {
-	versions, err := profile.InstalledVersions(component)
+func (env *Environment) DownloadComponentIfMissing(component string, version repository.Version) (repository.Version, error) {
+	versions, err := env.profile.InstalledVersions(component)
 	if err != nil {
 		return "", err
 	}
@@ -262,27 +161,36 @@ func DownloadComponentIfMissing(component string, version repository.Version) (r
 
 	if needDownload {
 		fmt.Printf("The component `%s` is not installed; downloading from repository.\n", component)
-		err := DownloadComponent(component, version, false)
+		err := env.DownloadComponent(component, version, false)
 		if err != nil {
 			return "", err
 		}
 	}
 
 	if version.IsEmpty() {
-		return SelectInstalledVersion(component, version)
+		return env.SelectInstalledVersion(component, version)
 	}
 
 	return version, nil
 }
 
 // LatestManifest returns the latest component manifest and refresh the local cache
-func LatestManifest() (*repository.ComponentManifest, error) {
-	manifest, err := repo.Manifest()
+func (env *Environment) LatestManifest() (*repository.ComponentManifest, error) {
+	manifest, err := env.repo.Manifest()
 	if err != nil {
 		return nil, err
 	}
-	if err := profile.SaveManifest(manifest); err != nil {
+	if err := env.profile.SaveManifest(manifest); err != nil {
 		return nil, err
 	}
 	return manifest, err
+}
+
+// ParseCompVersion parses component part from <component>[:version] specification
+func ParseCompVersion(spec string) (string, repository.Version) {
+	if strings.Contains(spec, ":") {
+		parts := strings.SplitN(spec, ":", 2)
+		return parts[0], repository.Version(parts[1])
+	}
+	return spec, ""
 }

--- a/pkg/repository/version_test.go
+++ b/pkg/repository/version_test.go
@@ -30,7 +30,7 @@ func (s *repositorySuite) TestVersions(c *C) {
 			},
 		},
 		Versions: []VersionInfo{
-			VersionInfo{
+			{
 				Version: "v0.0.1",
 				Date:    "data1",
 				Entry:   "entry",
@@ -38,7 +38,7 @@ func (s *repositorySuite) TestVersions(c *C) {
 					"linux/amd64", "darwin/amd64",
 				},
 			},
-			VersionInfo{
+			{
 				Version: "v0.0.3",
 				Date:    "date3",
 				Entry:   "entry",
@@ -46,7 +46,7 @@ func (s *repositorySuite) TestVersions(c *C) {
 					"linux/amd64", "darwin/amd64",
 				},
 			},
-			VersionInfo{
+			{
 				Version: "v0.0.2",
 				Date:    "date2",
 				Entry:   "entry",

--- a/tests/expected/tiup/tiup-help-doc.output
+++ b/tests/expected/tiup/tiup-help-doc.output
@@ -1,4 +1,4 @@
-The document about TiDB
+TiDB document summary page
 
 Usage:
   tiup doc [flags]

--- a/tests/expected/tiup/tiup-run-test-v1.1.1.output
+++ b/tests/expected/tiup/tiup-run-test-v1.1.1.output
@@ -1,3 +1,3 @@
 The component `test` is not installed; downloading from repository.
-Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin 
+Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin
 integration test v1.1.1

--- a/tests/expected/tiup/tiup-run-test.output
+++ b/tests/expected/tiup/tiup-run-test.output
@@ -1,3 +1,3 @@
 The component `test` is not installed; downloading from repository.
-Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.2/test.bin 
+Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.2/test.bin
 integration test v1.1.2

--- a/tests/expected/tiup/tiup-run-test0.output
+++ b/tests/expected/tiup/tiup-run-test0.output
@@ -1,3 +1,3 @@
 The component `test` is not installed; downloading from repository.
-Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.2/test.bin 
+Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.2/test.bin
 integration test v1.1.2

--- a/tests/expected/tiup/tiup-run-test2.output
+++ b/tests/expected/tiup/tiup-run-test2.output
@@ -1,2 +1,2 @@
-Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.2/test.bin 
+Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.2/test.bin
 integration test v1.1.2

--- a/tests/expected/tiup/tiup-run-test3.output
+++ b/tests/expected/tiup/tiup-run-test3.output
@@ -1,2 +1,2 @@
-Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin 
+Starting component `test`: TIUP_HOME_INTEGRATION_TEST/components/test/v1.1.1/test.bin
 integration test v1.1.1

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -94,7 +94,7 @@ do
         ;;
     esac
 
-    actual=$(cat "$TMP_DIR/$path" )
+    actual=$(cat "$TMP_DIR/$path")
     expected=$(cat "$TIUP_EXPECTED/$path")
 
     if [ "$expected" != "$actual" ]; then
@@ -105,7 +105,7 @@ do
       failed=$((failed+1))
 
       echo "${BOLD}-----------------------------------DIFF START-----------------------------------------${NORMAL}" >&2
-      diff --ignore-space-change -B -E -Z \
+      diff --ignore-space-change -B -E \
        --old-group-format="${RED}%<${NORMAL}" \
        --new-group-format="${GREEN}%>${NORMAL}" \
        --unchanged-group-format="" \


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR is a step towards making unit tests more unit-y and a better long-term test framework

cc #111

PTAL @lonng 

### What is changed and how it works?

The first commit refactors the list component so that it can be unit tested without also testing the generic running framework or the table writing code.

The second commit refactors the `profile` and `repo` globals into an `Environment` struct. This removes global, mutable state and will allow for tests to run concurrently using different environments.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 
(existing tests, all work is refactoring)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Side effects

none

Related changes

none