### PR TITLE
Always tidy up after tests, even if tests fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,10 @@ integration_test:
 	cd tests && bash run.sh ; \
 
 
-test: cover-dir failpoint-enable unit-test integration_test
-	@$(FAILPOINT_DISABLE)
+test: cover-dir failpoint-enable
+	make run-tests; STATUS=$$?; $(FAILPOINT_DISABLE); exit $$STATUS
+
+run-tests: unit-test integration_test
 
 coverage:
 	GO111MODULE=off go get github.com/wadey/gocovmerge

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -129,7 +129,6 @@ if [ $GITHUB_ACTION ]; then
 
   if [ ! -f "$TIUP_HOME/data/test-playground/dsn" ]; then
     echo "${RED}✖ Failed run playground${NORMAL}"
-    exit 1
   fi
 fi
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Previously if tests fail, then we never tidy up failpoints changes, so some changes are left to files, and some files which should be deleted are left in tree.

Closes #98


### What is changed and how it works?

Change the makefile to run tests recursively rather than directly, thus letting disable failpoints run.

PTAL @lonng 