### PR TITLE
Update `tiup bench` with more tpch flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ bin/
 *.out
 
 /.idea/
+/.vscode/
 /package/
 /tests/_tmp/
 /tests/tiup_home/

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,9 @@ pack:
 tiops:
 	make -C components/tiops package
 
+bench:
+	make -C components/bench package
+
 package: playground client pack tiops
 	mkdir -p package ; \
 	GOOS=darwin GOARCH=amd64 go build ; \

--- a/components/bench/Makefile
+++ b/components/bench/Makefile
@@ -1,0 +1,35 @@
+GOVER := $(shell go version)
+
+GOOS    := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
+GOARCH  := $(if $(GOARCH),$(GOARCH),amd64)
+GOENV   := GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH)
+GO      := $(GOENV) go
+GOBUILD := $(GO) build $(BUILD_FLAG)
+VERSION := "v0.0.2"
+
+default: build
+
+build: check
+	$(GO) build -o bin/bench
+
+lint:
+	@golint ./...
+
+vet:
+	$(GO) vet ./...
+
+check: lint vet
+
+clean:
+	@rm -rf bin
+
+package: check
+	GOOS=darwin GOARCH=amd64 go build ; \
+	tar -czf bench-$(VERSION)-darwin-amd64.tar.gz bench ; \
+	shasum bench-$(VERSION)-darwin-amd64.tar.gz | awk '{print $$1}' > bench-$(VERSION)-darwin-amd64.sha1 ; \
+	GOOS=linux GOARCH=amd64 go build ; \
+	tar -czf bench-$(VERSION)-linux-amd64.tar.gz bench; \
+	shasum bench-$(VERSION)-linux-amd64.tar.gz | awk '{print $$1}' > bench-$(VERSION)-linux-amd64.sha1 ; \
+	rm bench 
+
+.PHONY: cmd package

--- a/components/bench/misc.go
+++ b/components/bench/misc.go
@@ -11,6 +11,12 @@ import (
 )
 
 func checkPrepare(ctx context.Context, w workload.Workloader) {
+	// skip preparation check in csv case
+	if w.Name() == "tpcc-csv" {
+		fmt.Println("Skip preparing checking. Please load CSV data into database and check later.")
+		return
+	}
+
 	var wg sync.WaitGroup
 	wg.Add(threads)
 	for i := 0; i < threads; i++ {
@@ -38,7 +44,7 @@ func execute(ctx context.Context, w workload.Workloader, action string, index in
 	switch action {
 	case "prepare":
 		// Do cleanup only if dropData is set and not generate csv data.
-		if dropData && !w.DataGen() {
+		if dropData {
 			if err := w.Cleanup(ctx, index); err != nil {
 				return err
 			}
@@ -106,12 +112,8 @@ func executeWorkload(ctx context.Context, w workload.Workloader, action string) 
 	wg.Wait()
 
 	if action == "prepare" {
-		if !w.DataGen() {
-			// For prepare, we must check the data consistency after all prepare finished
-			checkPrepare(ctx, w)
-		} else {
-			fmt.Println("Skip preparing checking. Please load CSV data into database and check later.")
-		}
+		// For prepare, we must check the data consistency after all prepare finished
+		checkPrepare(ctx, w)
 	}
 	outputCancel()
 

--- a/components/bench/tpch.go
+++ b/components/bench/tpch.go
@@ -52,6 +52,29 @@ func registerTpch(root *cobra.Command) {
 		},
 	}
 
+	cmdPrepare.PersistentFlags().BoolVar(&tpchConfig.CreateTiFlashReplica,
+		"tiflash",
+		false,
+		"Create tiflash replica")
+
+	cmdPrepare.PersistentFlags().BoolVar(&tpchConfig.AnalyzeTable.Enable,
+		"analyze",
+		false,
+		"After data loaded, analyze table to collect column statistics")
+	// https://pingcap.com/docs/stable/reference/performance/statistics/#control-analyze-concurrency
+	cmdPrepare.PersistentFlags().IntVar(&tpchConfig.AnalyzeTable.BuildStatsConcurrency,
+		"tidb_build_stats_concurrency",
+		4,
+		"tidb_build_stats_concurrency param for analyze jobs")
+	cmdPrepare.PersistentFlags().IntVar(&tpchConfig.AnalyzeTable.DistsqlScanConcurrency,
+		"tidb_distsql_scan_concurrency",
+		15,
+		"tidb_distsql_scan_concurrency param for analyze jobs")
+	cmdPrepare.PersistentFlags().IntVar(&tpchConfig.AnalyzeTable.IndexSerialScanConcurrency,
+		"tidb_index_serial_scan_concurrency",
+		1,
+		"tidb_index_serial_scan_concurrency param for analyze jobs")
+
 	var cmdRun = &cobra.Command{
 		Use:   "run",
 		Short: "Run workload",

--- a/doc/user/bench.md
+++ b/doc/user/bench.md
@@ -124,7 +124,10 @@ Flags:
 1. Data preparation
 
 ```shell
+# Prepare data with scale factor 1
 tiup bench tpch --sf=1 prepare
+# Or prepare data with scale factor 1, create tiflash replica, and analyze table after data loaded
+tiup bench tpch --sf=1 --analyze --tiflash prepare
 ```
 
 2. Benchmarking and checking results

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
 	github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011
 	github.com/pingcap/failpoint v0.0.0-20200210140405-f8f9fb234798
-	github.com/pingcap/go-tpc v1.0.4-0.20200410025347-ee3e3247e342
+	github.com/pingcap/go-tpc v1.0.4-0.20200511044254-883c1a10d555
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil v2.20.2+incompatible
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011 h1:58naV4XMEqm0h
 github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/failpoint v0.0.0-20200210140405-f8f9fb234798 h1:6DMbRqPI1qzQ8N1xc3+nKY8IxSACd9VqQKkRVvbyoIg=
 github.com/pingcap/failpoint v0.0.0-20200210140405-f8f9fb234798/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
-github.com/pingcap/go-tpc v1.0.4-0.20200410025347-ee3e3247e342 h1:vGJb2pgoKK1Zj2X56GGpzpCd01DRyhagBdCRVu896DM=
-github.com/pingcap/go-tpc v1.0.4-0.20200410025347-ee3e3247e342/go.mod h1:YToE6BW+r+aWksQm1kuFnzKgEzaTKsVIHD36rxVYaWc=
+github.com/pingcap/go-tpc v1.0.4-0.20200511044254-883c1a10d555 h1:KnjhPPzKAB3V8K18rCpQ+H+TDRBFv7NT/kwevZl/fRw=
+github.com/pingcap/go-tpc v1.0.4-0.20200511044254-883c1a10d555/go.mod h1:YToE6BW+r+aWksQm1kuFnzKgEzaTKsVIHD36rxVYaWc=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww9rkZ1DnWfl0pXV3BOWlkYIjA=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
* Port latest changes in [pingcap/go-tpc](https://github.com/pingcap/go-tpc) to make it more friendly to run a benchmark on TiDB cluster with TiFlash.


### What is changed and how it works?
* Port latest files in `pingcap/go-tpc` · `cmd/go-tpc` to `components/bench`
* Add Makefile for components/bench

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - None

Side effects

 - Breaking backward compatibility

Related changes

 - Need to release a new version of `tiup bench`
