### PR TITLE
implement update root

### DIFF
--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -174,7 +174,7 @@ func (r *V1Repository) updateLocalRoot(local v1manifest.LocalManifests) error {
 	}
 
 	for _, m := range newRoots {
-		filename := fmt.Sprintf("%v.%s", m.Signed.Base().Version, v1manifest.ManifestFilenameRoot)
+		filename := fnameWithVersion(v1manifest.ManifestTypeRoot, m.Signed.Base().Version)
 		err = local.SaveManifest(&m, filename)
 		if err != nil {
 			return errors.AddStack(err)

--- a/pkg/repository/v1manifest/manifest.go
+++ b/pkg/repository/v1manifest/manifest.go
@@ -119,6 +119,7 @@ func (manifest *Manifest) VerifySignature(threshold uint, keys crypto.KeyStore) 
 			// TODO use SignatureError
 			err := fmt.Errorf("signature key %s not found", sig.KeyID)
 			errs = append(errs, err)
+			continue
 		}
 		err := key.Verify(payload, sig.Sig)
 		if err != nil {

--- a/pkg/repository/v1manifest/manifest.go
+++ b/pkg/repository/v1manifest/manifest.go
@@ -91,10 +91,18 @@ var ManifestsConfig = map[string]ty{
 
 var knownVersions = map[string]struct{}{"0.1.0": {}}
 
-// verifySignature ensures that each signature in manifest::signatures is a valid signature of manifest::signed.
-func (manifest *Manifest) verifySignature(keys crypto.KeyStore) error {
+// VerifySignature ensures that threshold signature in manifest::signatures is a valid signature of manifest::signed.
+func (manifest *Manifest) VerifySignature(threshold uint, keys crypto.KeyStore) error {
 	if keys == nil {
 		return nil
+	}
+
+	if threshold == 0 {
+		return nil
+	}
+
+	if len(manifest.Signatures) < int(threshold) {
+		return errors.Errorf("only %d signature but need %d", len(manifest.Signatures), threshold)
 	}
 
 	payload, err := cjson.Marshal(manifest.Signed)
@@ -102,20 +110,29 @@ func (manifest *Manifest) verifySignature(keys crypto.KeyStore) error {
 		return nil
 	}
 
+	var validCount uint
+	var errs []error
 	for _, sig := range manifest.Signatures {
 		// TODO check that KeyID belongs to a role which is authorised to sign this manifest
 		key := keys.Get(sig.KeyID)
 		if key == nil {
 			// TODO use SignatureError
-			return fmt.Errorf("signature key %s not found", sig.KeyID)
+			err := fmt.Errorf("signature key %s not found", sig.KeyID)
+			errs = append(errs, err)
 		}
-		if err := key.Verify(payload, sig.Sig); err != nil {
-			// TODO use SignatureError
-			return err
+		err := key.Verify(payload, sig.Sig)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			validCount++
 		}
 	}
 
-	return nil
+	if validCount >= threshold {
+		return nil
+	}
+
+	return errors.Errorf("only %d signature valid but need %d", validCount, threshold)
 }
 
 // SignatureError the signature of a file is incorrect.
@@ -145,6 +162,20 @@ func (s *SignedBase) Versioned() bool {
 	return ManifestsConfig[s.Ty].Versioned
 }
 
+// CheckExpire return not nil if it's expired.
+func CheckExpire(expires string) error {
+	expiresTime, err := time.Parse(time.RFC3339, expires)
+	if err != nil {
+		return errors.AddStack(err)
+	}
+
+	if expiresTime.Before(time.Now()) {
+		return fmt.Errorf("manifest has expired at: %s", expires)
+	}
+
+	return nil
+}
+
 func (s *SignedBase) expiryTime() (time.Time, error) {
 	return time.Parse(time.RFC3339, s.Expires)
 }
@@ -159,13 +190,8 @@ func (s *SignedBase) isValid() error {
 		return fmt.Errorf("unknown manifest version: `%s`", s.SpecVersion)
 	}
 
-	expires, err := s.expiryTime()
-	if err != nil {
-		return err
-	}
-
-	if expires.Before(time.Now()) {
-		return fmt.Errorf("manifest has expired at: %s", s.Expires)
+	if err := CheckExpire(s.Expires); err != nil {
+		return errors.AddStack(err)
 	}
 
 	return nil
@@ -261,7 +287,7 @@ func ReadManifest(input io.Reader, role ValidManifest, keys crypto.KeyStore) (*M
 		return nil, errors.New("no signatures supplied in manifest")
 	}
 
-	err = m.verifySignature(keys)
+	err = m.VerifySignature(uint(len(m.Signatures)), keys)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/v1manifest/repo.go
+++ b/pkg/repository/v1manifest/repo.go
@@ -366,7 +366,7 @@ func FreshKeyInfo() (*KeyInfo, string, crypto.PrivKey, error) {
 		return nil, "", nil, err
 	}
 	info := KeyInfo{
-		Algorithms: []string{SHA256},
+		Algorithms: []string{SHA256, SHA512},
 		Type:       "rsa",
 		Value:      map[string]string{"public": string(pubBytes)},
 		Scheme:     "rsassa-pss-sha256",

--- a/pkg/repository/v1manifest/types.go
+++ b/pkg/repository/v1manifest/types.go
@@ -13,6 +13,8 @@
 
 package v1manifest
 
+import "github.com/pingcap-incubator/tiup/pkg/repository/crypto"
+
 // Manifest representation for ser/de.
 type Manifest struct {
 	// Signatures value
@@ -137,6 +139,22 @@ type FileVersion struct {
 // Base implements ValidManifest
 func (manifest *Root) Base() *SignedBase {
 	return &manifest.SignedBase
+}
+
+// GetRootKeyStore create KeyStore of root keys.
+func (manifest *Root) GetRootKeyStore() (ks crypto.KeyStore, err error) {
+	ks = crypto.NewKeyStore()
+
+	role := manifest.Roles[ManifestTypeRoot]
+	for id, info := range role.Keys {
+		pub, err := info.publicKey()
+		if err != nil {
+			return nil, err
+		}
+		ks.Put(id, pub)
+	}
+
+	return
 }
 
 // Base implements ValidManifest

--- a/pkg/repository/v1manifest/types.go
+++ b/pkg/repository/v1manifest/types.go
@@ -93,10 +93,11 @@ type VersionItem struct {
 // Component manifest.
 type Component struct {
 	SignedBase
-	ID          string                            `json:"id"`
-	Name        string                            `json:"name"`
-	Description string                            `json:"description"`
-	Platforms   map[string]map[string]VersionItem `json:"platforms"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	// platform -> version -> VersionItem
+	Platforms map[string]map[string]VersionItem `json:"platforms"`
 }
 
 // ComponentItem object


### PR DESCRIPTION
implement update root

Seems we should VerifySignature according to the threshold of the manifest type but not just all signatures?
Also we should update the keys of `LocalRoot` when we get or save a new root manifest