### PR TITLE
repository: fix tarball downloading

### DIFF
--- a/pkg/repository/file_source.go
+++ b/pkg/repository/file_source.go
@@ -102,6 +102,7 @@ func (fs *mirrorSource) downloadTarFile(targetDir, resName string, expand bool) 
 	if !ok {
 		return errors.Errorf("expected file, found %v", tarReader)
 	}
+	// make sure to read from file start, it was read once in CheckSHA()
 	_, err = tarFile.Seek(0, 0)
 	if err != nil {
 		return errors.Trace(err)

--- a/pkg/repository/file_source.go
+++ b/pkg/repository/file_source.go
@@ -81,14 +81,10 @@ func (fs *mirrorSource) downloadTarFile(targetDir, resName string, expand bool) 
 	}
 
 	var tarReader io.ReadCloser
-	if expand {
-		tarReader, err = fs.mirror.Fetch(resName, 0)
-	} else {
-		if err := fs.mirror.Download(resName, targetDir); err != nil {
-			return errors.Trace(err)
-		}
-		tarReader, err = os.OpenFile(filepath.Join(targetDir, resName), os.O_RDONLY, 0)
+	if err := fs.mirror.Download(resName, targetDir); err != nil {
+		return errors.Trace(err)
 	}
+	tarReader, err = os.OpenFile(filepath.Join(targetDir, resName), os.O_RDONLY, 0)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/repository/mirror.go
+++ b/pkg/repository/mirror.go
@@ -227,6 +227,9 @@ func (l *httpMirror) prepareURL(resource string) string {
 func (l *httpMirror) Download(resource, targetDir string) error {
 	tmpFilePath := filepath.Join(l.tmpDir, resource)
 	dstFilePath := filepath.Join(targetDir, resource)
+	// downloaded file is stored in a temp directory and the temp directory is
+	// deleted at Close(), in this way an interrupted download won't remain
+	// any partial file on the disk
 	r, err := l.download(l.prepareURL(resource), tmpFilePath, 0)
 	if err != nil {
 		return errors.Trace(err)

--- a/pkg/repository/v1manifest/repo.go
+++ b/pkg/repository/v1manifest/repo.go
@@ -202,11 +202,8 @@ NextKey:
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(mfile, content, 0664); err != nil {
-		return err
-	}
 
-	return nil
+	return ioutil.WriteFile(mfile, content, 0664)
 }
 
 // AddComponent adds a new component to an existing repository

--- a/pkg/utils/ioutil.go
+++ b/pkg/utils/ioutil.go
@@ -122,7 +122,8 @@ func Copy(src, dst string) error {
 }
 
 // Move moves a file from src to dst, this is done by copying the file and then
-// delete the old one. Use os.Rename() to rename file within the filesystem
+// delete the old one. Use os.Rename() to rename file within the same filesystem
+// instead this, it's more lightweight but can not be used accross devices.
 func Move(src, dst string) error {
 	if err := Copy(src, dst); err != nil {
 		return err

--- a/pkg/utils/ioutil.go
+++ b/pkg/utils/ioutil.go
@@ -120,3 +120,12 @@ func Copy(src, dst string) error {
 	}
 	return out.Close()
 }
+
+// Move moves a file from src to dst, this is done by copying the file and then
+// delete the old one. Use os.Rename() to rename file within the filesystem
+func Move(src, dst string) error {
+	if err := Copy(src, dst); err != nil {
+		return err
+	}
+	return os.Remove(src)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When downloading tarball, it fails to decompress

### What is changed and how it works?
There was a `FIXME` comment that suggests to store downloaded files in memory other than files to reduce disk IO, but after fixing that, the behavior of handling tarballs are not correct.

In `pkg/repository/file_source.go`, we check file hash before decompress it, so the returned reader was read twice if `expand` is true, the 2nd read can only get `EOF`. There is a `Seek()` call to reset the offset before decompressing, however, this only works for `os.File`, but not other reader types.

This PR partially revert #213 and changed the process back to storing downloaded files on disk in a temp dir. (This also avoids the risk that downloading large file may lead to too much memory usage)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has persistent data change

Side effects

 - Possible performance regression

Related changes

 - Need to cherry-pick to the release branch
