### PR TITLE
Support `repo sign` subcommand for manually sign

### DIFF
--- a/pkg/repository/crypto/keys.go
+++ b/pkg/repository/crypto/keys.go
@@ -112,6 +112,7 @@ func (s *keychain) KeyIDs() []string {
 func NewKeyPair(keyType, keyScheme string) (PubKey, PrivKey, error) {
 	// We only support RSA now
 	if keyType != KeyTypeRSA {
+		panic(keyType)
 		return nil, nil, ErrorUnsupportedKeyType
 	}
 
@@ -127,6 +128,7 @@ func NewKeyPair(keyType, keyScheme string) (PubKey, PrivKey, error) {
 func NewPrivKey(keyType, keyScheme string, key []byte) (PrivKey, error) {
 	// We only support RSA now
 	if keyType != KeyTypeRSA {
+		panic(keyType)
 		return nil, ErrorUnsupportedKeyType
 	}
 
@@ -143,6 +145,7 @@ func NewPrivKey(keyType, keyScheme string, key []byte) (PrivKey, error) {
 func NewPubKey(keyType, keyScheme string, key []byte) (PubKey, error) {
 	// We only support RSA now
 	if keyType != KeyTypeRSA {
+		panic(keyType)
 		return nil, ErrorUnsupportedKeyType
 	}
 

--- a/pkg/repository/crypto/keys.go
+++ b/pkg/repository/crypto/keys.go
@@ -112,7 +112,6 @@ func (s *keychain) KeyIDs() []string {
 func NewKeyPair(keyType, keyScheme string) (PubKey, PrivKey, error) {
 	// We only support RSA now
 	if keyType != KeyTypeRSA {
-		panic(keyType)
 		return nil, nil, ErrorUnsupportedKeyType
 	}
 
@@ -128,7 +127,6 @@ func NewKeyPair(keyType, keyScheme string) (PubKey, PrivKey, error) {
 func NewPrivKey(keyType, keyScheme string, key []byte) (PrivKey, error) {
 	// We only support RSA now
 	if keyType != KeyTypeRSA {
-		panic(keyType)
 		return nil, ErrorUnsupportedKeyType
 	}
 
@@ -145,7 +143,6 @@ func NewPrivKey(keyType, keyScheme string, key []byte) (PrivKey, error) {
 func NewPubKey(keyType, keyScheme string, key []byte) (PubKey, error) {
 	// We only support RSA now
 	if keyType != KeyTypeRSA {
-		panic(keyType)
 		return nil, ErrorUnsupportedKeyType
 	}
 

--- a/pkg/repository/v1manifest/repo.go
+++ b/pkg/repository/v1manifest/repo.go
@@ -157,7 +157,7 @@ func SignManifestFile(mfile string, kfiles ...string) error {
 	if err := json.Unmarshal(content, &m); err != nil {
 		return err
 	}
-	payload, err := json.Marshal(m.Signed)
+	payload, err := cjson.Marshal(m.Signed)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR introduce a sub command:
```
tiup repo sign <manifest-file> [key1] [key2]
```

It will append signature to the manifest file

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

```
cat /tmp/repo/timestamp.json
tiup repo init /tmp/repo -i /tmp/keys
tiup repo sign /tmp/repo/timestamp.json /tmp/keys/*-root.json
cat /tmp/repo/timestamp.json
```

Code changes


Side effects


Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
