### PR TITLE
Make run components works for v1

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newHelpCmd(profile *localdata.Profile) *cobra.Command {
+func newHelpCmd(env *meta.Environment) *cobra.Command {
 	return &cobra.Command{
 		Use:   "help [command]",
 		Short: "Help about any command or component",
@@ -35,7 +35,7 @@ Simply type tiup help <command>|<component> for full details.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd, n, e := cmd.Root().Find(args)
 			if (cmd == rootCmd || e != nil) && len(n) > 0 {
-				externalHelp(profile, n[0], n[1:]...)
+				externalHelp(env, n[0], n[1:]...)
 			} else {
 				cmd.InitDefaultHelpFlag() // make possible 'help' flag to be shown
 				cmd.HelpFunc()(cmd, args)
@@ -44,14 +44,15 @@ Simply type tiup help <command>|<component> for full details.`,
 	}
 }
 
-func externalHelp(profile *localdata.Profile, spec string, args ...string) {
+func externalHelp(env *meta.Environment, spec string, args ...string) {
+	profile := env.Profile()
 	component, version := meta.ParseCompVersion(spec)
 	selectVer, err := profile.SelectInstalledVersion(component, version)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	binaryPath, err := profile.BinaryPath(component, selectVer)
+	binaryPath, err := env.BinaryPath(component, selectVer)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,7 +60,7 @@ the latest stable version will be downloaded from the repository.`,
 				if err != nil {
 					return err
 				}
-				binaryPath, err := env.Profile().BinaryPath(component, selectedVer)
+				binaryPath, err := env.BinaryPath(component, selectedVer)
 				if err != nil {
 					return err
 				}
@@ -124,13 +124,13 @@ the latest stable version will be downloaded from the repository.`,
 		}
 		cmd, n, e := cmd.Root().Find(args)
 		if (cmd == rootCmd || e != nil) && len(n) > 0 {
-			externalHelp(env.Profile(), n[0], n[1:]...)
+			externalHelp(env, n[0], n[1:]...)
 		} else {
 			cmd.InitDefaultHelpFlag() // make possible 'help' flag to be shown
 			cmd.Help()
 		}
 	})
-	rootCmd.SetHelpCommand(newHelpCmd(env.Profile()))
+	rootCmd.SetHelpCommand(newHelpCmd(env))
 	rootCmd.SetUsageTemplate(usageTemplate(env.Profile()))
 }
 

--- a/pkg/localdata/profile.go
+++ b/pkg/localdata/profile.go
@@ -68,6 +68,7 @@ func (p *Profile) Root() string {
 }
 
 // BinaryPath returns the binary path of component specific version
+// TODO rename this func name and update the caller, since only v0 can call this
 func (p *Profile) BinaryPath(component string, version v0manifest.Version) (string, error) {
 	manifest := p.Versions(component)
 	if manifest == nil {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -160,8 +160,61 @@ func (env *Environment) SelfUpdate() error {
 	return env.repo.DownloadTiup(env.LocalPath("bin"))
 }
 
+func (env *Environment) downloadCompoentv1(component string, version v0manifest.Version, overwrite bool) error {
+	com, err := env.v1Repo.FetchComponent(component)
+	if err != nil {
+		return err
+	}
+
+	if version.IsNightly() && !com.HasNightly() {
+		fmt.Printf("The component `%s` does not have a nightly version; skipped.\n", component)
+		return nil
+	}
+
+	platform := env.v1Repo.PlatformString()
+	var versionIem *v1manifest.VersionItem
+	if version.IsEmpty() {
+		var ok bool
+		version, versionIem, ok = com.LatestVersion(platform)
+		if !ok {
+			fmt.Printf("The component `%s` does not support %s; skipped.\n", component, platform)
+			return nil
+		}
+	} else {
+		versions, ok := com.Platforms[platform]
+		if !ok {
+			fmt.Printf("The component `%s` does not support %s; skipped.\n", component, platform)
+			return nil
+		}
+		item, ok := versions[string(version)]
+		if !ok {
+			fmt.Printf("The component `%s` does not support %s; skipped.\n", component, version)
+			return nil
+		}
+		versionIem = &item
+	}
+
+	if !overwrite {
+		// Ignore if installed
+		found, err := env.profile.VersionIsInstalled(component, version.String())
+		if err != nil {
+			return err
+		}
+		if found {
+			fmt.Printf("The component `%s:%s` has been installed.\n", component, version)
+			return nil
+		}
+	}
+
+	return env.v1Repo.DownloadComponent(component, version, versionIem)
+}
+
 // downloadComponent downloads the specific version of a component from repository
 func (env *Environment) downloadComponent(component string, version v0manifest.Version, overwrite bool) error {
+	if env.v1Repo != nil {
+		return env.downloadCompoentv1(component, version, overwrite)
+	}
+
 	versions, err := env.repo.ComponentVersions(component)
 	if err != nil {
 		return err
@@ -255,6 +308,19 @@ func (env *Environment) latestManifest() (*v0manifest.ComponentManifest, error) 
 	return manifest, err
 }
 
+// BinaryPath return the installed binary path.
+func (env *Environment) BinaryPath(component string, version v0manifest.Version) (string, error) {
+	if env.v1Repo != nil {
+		installPath, err := env.profile.ComponentInstalledPath(component, version)
+		if err != nil {
+			return "", err
+		}
+		return env.v1Repo.BinaryPath(installPath, component, version)
+	}
+
+	return env.profile.BinaryPath(component, version)
+}
+
 // ParseCompVersion parses component part from <component>[:version] specification
 func ParseCompVersion(spec string) (string, v0manifest.Version) {
 	if strings.Contains(spec, ":") {
@@ -262,4 +328,32 @@ func ParseCompVersion(spec string) (string, v0manifest.Version) {
 		return parts[0], v0manifest.Version(parts[1])
 	}
 	return spec, ""
+}
+
+// IsSupportedComponent return true if support if platform support the component.
+func (env *Environment) IsSupportedComponent(component string) bool {
+	if env.v1Repo != nil {
+		// TODO
+		return true
+	}
+
+	// check local manifest
+	manifest := env.Profile().Manifest()
+	if manifest != nil && manifest.HasComponent(component) {
+		return true
+	}
+
+	manifest, err := env.Repository().Manifest()
+	if err != nil {
+		fmt.Println("Fetch latest manifest error:", err)
+		return false
+	}
+	if err := env.Profile().SaveManifest(manifest); err != nil {
+		fmt.Println("Save latest manifest error:", err)
+	}
+	comp, found := manifest.FindComponent(component)
+	if !found {
+		return false
+	}
+	return comp.IsSupport(env.PlatformString())
 }

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -160,7 +160,7 @@ func (env *Environment) SelfUpdate() error {
 	return env.repo.DownloadTiup(env.LocalPath("bin"))
 }
 
-func (env *Environment) downloadCompoentv1(component string, version v0manifest.Version, overwrite bool) error {
+func (env *Environment) downloadComponentv1(component string, version v0manifest.Version, overwrite bool) error {
 	com, err := env.v1Repo.FetchComponent(component)
 	if err != nil {
 		return err
@@ -212,7 +212,7 @@ func (env *Environment) downloadCompoentv1(component string, version v0manifest.
 // downloadComponent downloads the specific version of a component from repository
 func (env *Environment) downloadComponent(component string, version v0manifest.Version, overwrite bool) error {
 	if env.v1Repo != nil {
-		return env.downloadCompoentv1(component, version, overwrite)
+		return env.downloadComponentv1(component, version, overwrite)
 	}
 
 	versions, err := env.repo.ComponentVersions(component)

--- a/pkg/repository/v1manifest/local_manifests.go
+++ b/pkg/repository/v1manifest/local_manifests.go
@@ -36,7 +36,7 @@ type LocalManifests interface {
 	// LoadManifest loads and validates the most recent manifest of role's type. The returned bool is true if the file
 	// exists.
 	LoadManifest(role ValidManifest) (bool, error)
-	// LoadComponentManifest loads and validates the most recent manifest at filename.
+	// LoadComponentManifest loads and validates the most recent manifest at filename if passing a not nil index.
 	LoadComponentManifest(index *Index, filename string) (*Component, error)
 	// ComponentInstalled is true if the version of component is present locally.
 	ComponentInstalled(component, version string) (bool, error)

--- a/pkg/repository/v1manifest/types.go
+++ b/pkg/repository/v1manifest/types.go
@@ -17,7 +17,9 @@ import (
 	"time"
 
 	"github.com/pingcap-incubator/tiup/pkg/repository/crypto"
+	"github.com/pingcap-incubator/tiup/pkg/repository/v0manifest"
 	"github.com/pingcap/errors"
+	"golang.org/x/mod/semver"
 )
 
 // Manifest representation for ser/de.
@@ -252,4 +254,29 @@ func (manifest *Snapshot) Filename() string {
 // Filename implements ValidManifest
 func (manifest *Timestamp) Filename() string {
 	return ManifestFilenameTimestamp
+}
+
+// HasNightly return true if the component has nightly version.
+func (manifest *Component) HasNightly() bool {
+	// TODO how to support nightly??
+	return false
+}
+
+// LatestVersion return the latest version of the component.
+func (manifest *Component) LatestVersion(platform string) (v0manifest.Version, *VersionItem, bool) {
+	versions, ok := manifest.Platforms[platform]
+	if !ok || len(versions) == 0 {
+		return "", nil, false
+	}
+
+	var latest string
+	var latestItem VersionItem
+	for version, item := range versions {
+		if latest == "" || semver.Compare(version, latest) < 0 {
+			latest = version
+			latestItem = item
+		}
+	}
+
+	return v0manifest.Version(latest), &latestItem, true
 }


### PR DESCRIPTION
Make run components works for v1

test (see #245 for what is `tt` here)
```
➜  tiup git:(check_com) ✗ tt tidb
The component `tidb` is not installed; downloading from repository.
Starting component `tidb`: /Users/huangjiahao/code/tiup/testprofile/components/tidb/master/tidb-server
[2020/05/24 23:14:20.712 +08:00] [INFO] [printer.go:41] ["Welcome to TiDB."] ["Release Version"=v4.0.0-beta-447-gad63c03e50] ["Git Commit Hash"=ad63c03e5090e9fed17d39e05938630f895a53b1] ["Git Branch"=HEAD] ["UTC Build Time"="2020-03-18 12:07:57"] [GoVersion=go1.13.4] ["Race Enabled"=false] ["Check Table Before Drop"=false] ["TiKV Min Version"=v3.0.0-60965b006877ca7234adaced7890d7b029ed1306]
[2020/05/24 23:14:20.713 +08:00] [INFO] [printer.go:54] ["loaded config"] [config="{\"host\":\"0.0.0.0\",\"advertise-address\":\"0.0.0.0\",\"port\":4000,\"cors\":\"\",\"store\":\"mocktikv\",\"path\":\"/tmp/tidb\",\"socket\":\"\",\"lease\":\"45s\",\"run-ddl\":true,\"split-table\":true,\"token-limit\":1000,\"oom-use-tmp-storage\":true,\"tmp-storage-path\":\"/var/folders/nw/c0ncybdd6gj2f5w5tmqvk9y40000gn/T/tidb/tmp-storage\",\"oom-action\":\"cancel\",\"mem-quota-query\":1073741824,\"enable-streaming\":false,\"enable-batch-dml\":false,\"txn-local-latches\":{\"enabled\":false,\"capacity\":2048000},\"lower-case-table-names\":2,\"server-version\":\"\",\"log\":{\"level\":\"info\",\"format\":\"text\",\"disable-timestamp\":null,\"enable-timestamp\":null,\"disable-error-stack\":null,\"enable-error-stack\":null,\"file\":{\"filename\":\"\",\"max-size\":300,\"max-days\":0,\"max-backups\":0},\"enable-slow-log\":true,\"slow-query-file\":\"tidb-slow.log\",\"slow-threshold\":300,\"expensive-threshold\":10000,\"query-log-max-len\":4096,\"record-plan-in-slow-log\":1},\"security\":{\"skip-grant-table\":false,\"ssl-ca\":\"\",\"ssl-cert\":\"\",\"ssl-key\":\"\",\"require-secure-transport\":false,\"cluster-ssl-ca\":\"\",\"cluster-ssl-cert\":\"\",\"cluster-ssl-key\":\"\",\"cluster-verify-cn\":null},\"status\":{\"status-host\":\"0.0.0.0\",\"metrics-addr\":\"\",\"status-port\":10080,\"metrics-interval\":15,\"report-status\":true,\"record-db-qps\":false},\"performance\":{\"max-procs\":0,\"max-memory\":0,\"stats-lease\":\"3s\",\"stmt-count-limit\":5000,\"feedback-probability\":0.05,\"query-feedback-limit\":1024,\"pseudo-estimate-ratio\":0.8,\"force-priority\":\"NO_PRIORITY\",\"bind-info-lease\":\"3s\",\"txn-total-size-limit\":104857600,\"tcp-keep-alive\":true,\"cross-join\":true,\"run-auto-analyze\":true},\"prepared-plan-cache\":{\"enabled\":false,\"capacity\":100,\"memory-guard-ratio\":0.1},\"opentracing\":{\"enable\":false,\"rpc-metrics\":false,\"sampler\":{\"type\":\"const\",\"param\":1,\"sampling-server-url\":\"\",\"max-operations\":0,\"sampling-refresh-interval\":0},\"reporter\":{\"queue-size\":0,\"buffer-flush-interval\":0,\"log-spans\":false,\"local-agent-host-port\":\"\"}},\"proxy-protocol\":{\"networks\":\"\",\"header-timeout\":5},\"tikv-client\":{\"grpc-connection-count\":4,\"grpc-keepalive-time\":10,\"grpc-keepalive-timeout\":3,\"commit-timeout\":\"41s\",\"max-batch-size\":128,\"overload-threshold\":200,\"max-batch-wait-time\":0,\"batch-wait-size\":8,\"enable-chunk-rpc\":true,\"region-cache-ttl\":600,\"store-limit\":0,\"copr-cache\":{\"enabled\":false,\"capacity-mb\":0,\"admission-max-result-mb\":0,\"admission-min-process-ms\":0}},\"binlog\":{\"enable\":false,\"ignore-error\":false,\"write-timeout\":\"15s\",\"binlog-socket\":\"\",\"strategy\":\"range\"},\"compatible-kill-query\":false,\"plugin\":{\"dir\":\"\",\"load\":\"\"},\"pessimistic-txn\":{\"enable\":true,\"max-retry-count\":256},\"check-mb4-value-in-utf8\":true,\"max-index-length\":3072,\"alter-primary-key\":false,\"treat-old-version-utf8-as-utf8mb4\":true,\"enable-table-lock\":false,\"delay-clean-table-lock\":0,\"split-region-max-num\":1000,\"stmt-summary\":{\"enable\":true,\"max-stmt-count\":200,\"max-sql-length\":4096,\"refresh-interval\":1800,\"history-size\":24},\"repair-mode\":false,\"repair-table-list\":[],\"isolation-read\":{\"engines\":[\"tikv\",\"tiflash\",\"tidb\"]},\"max-server-connections\":4096,\"new_collations_enabled_on_first_bootstrap\":false,\"experimental\":{\"allow-auto-random\":false},\"enable-dynamic-config\":true}"]
[2020/05/24 23:14:20.714 +08:00] [INFO] [main.go:280] ["disable Prometheus push client"]
[2020/05/24 23:14:20.714 +08:00] [INFO] [systime_mon.go:25] ["start system time monitor"]
[2020/05/24 23:14:20.714 +08:00] [INFO] [store.go:68] ["new store"] [path=mocktikv:///tmp/tidb]
```

```
➜  tiup git:(check_com) ✗ tt install tikv
➜  tiup git:(check_com) ✗ tt tikv -h
TiKV
Release Version:   4.0.0-rc.2
Edition:           Community
Git Commit Hash:   2fdb2804bf8ffaab4b18c4996970e19906296497
Git Commit Branch: HEAD
UTC Build Time:    2020-05-15 12:32:21
Rust Version:      rustc 1.42.0-nightly (0de96d37f 2019-12-19)
Enable Features:   jemalloc sse protobuf-codec
Profile:           dist_release

A distributed transactional key-value database powered by Rust and Raft

USAGE:
    tikv-server [FLAGS] [OPTIONS]

FLAGS:
        --config-check           Check config file validity and exit
    -h, --help                   Prints help information
```

Note silently after install successfully, I will refine it later.