### PR TITLE
manifest: save private key with 0600 permission

### DIFF
--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -240,6 +240,11 @@ func newRepoGenkeyCmd(env *meta.Environment) *cobra.Command {
 			}
 			defer f.Close()
 
+			// set private key permission
+			if err = f.Chmod(0600); err != nil {
+				return err
+			}
+
 			if err := json.NewEncoder(f).Encode(key); err != nil {
 				return err
 			}

--- a/pkg/repository/v1manifest/repo.go
+++ b/pkg/repository/v1manifest/repo.go
@@ -120,6 +120,13 @@ func SaveKeyInfo(key *KeyInfo, ty, dir string) error {
 	}
 	defer f.Close()
 
+	if _, found := key.Value["private"]; found {
+		err = f.Chmod(0600)
+		if err != nil {
+			return err
+		}
+	}
+
 	return json.NewEncoder(f).Encode(key)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Save keyinfo files with `0600` if it contains private key

### What is changed and how it works?
Check if the `KeyInfo` contains private key block before saving it to disk

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has persistent data change

Side effects

 - N/A

Related changes

 - N/A
