### PR TITLE
*: add basic support of nightly versions

### DIFF
--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -96,6 +96,7 @@ func newRepoSignCmd(env *meta.Environment) *cobra.Command {
 
 // the `repo add` sub command
 func newRepoAddCompCmd(env *meta.Environment) *cobra.Command {
+	var nightly bool // if this is a nightly version
 	cmd := &cobra.Command{
 		Use:   "add <component-id> <platform> <version> <file>",
 		Short: "Add a file to a component",
@@ -105,14 +106,18 @@ func newRepoAddCompCmd(env *meta.Environment) *cobra.Command {
 				return cmd.Help()
 			}
 
-			return addCompFile(repoPath, args[0], args[1], args[2], args[3])
+			return addCompFile(repoPath, args[0], args[1], args[2], args[3], nightly)
 		},
 	}
+
+	// If adding legacy nightly build (e.g., add a version from yesterday), just
+	// omit the flag to treat it as normal versions
+	cmd.Flags().BoolVar(&nightly, "nightly", false, "Mark this version as the latest nightly build")
 
 	return cmd
 }
 
-func addCompFile(repo, id, platform, version, file string) error {
+func addCompFile(repo, id, platform, version, file string, nightly bool) error {
 	// TODO
 	return nil
 }
@@ -167,7 +172,9 @@ may still be available for them.`,
 }
 
 func delComp(repo, id, version string) error {
-	// TODO
+	// TODO: implement the func
+
+	// TODO: check if version is the latest nightly, refuse if it is
 	return nil
 }
 

--- a/doc/design/manifest.md
+++ b/doc/design/manifest.md
@@ -278,7 +278,13 @@ Where xxx is the id of the component, n is the version of the manifest, file is 
 
 The platform id should be one of the supported TiUp target triples. Version ids must be valid semver. Dependencies are a map from component id to a semver version string.
 
-The "nightly" points to the version number of latest daily build, that version should be in the version list of all supported platforms.
+The "nightly" points to the version number of latest daily build, that version should be in the version list of all supported platforms. The version number of nightly build should (but not forced to be) in the following format:
+
+```
+vX.Y.Z-nightly+YYYYmmdd
+```
+
+Where `vX.Y.Z` is the version of the last released version of that component.
 
 ### snapshot.json
 

--- a/doc/design/manifest.md
+++ b/doc/design/manifest.md
@@ -255,6 +255,7 @@ Where xxx is the id of the component, n is the version of the manifest, file is 
 ```
 "name": "Name of the Component",
 "description": "This is a component",
+"nightly": "0.2.0-nightly-20200525",
 "platforms": {
     "x86_64-apple-darwin": {
         "0.0.1": {
@@ -277,6 +278,7 @@ Where xxx is the id of the component, n is the version of the manifest, file is 
 
 The platform id should be one of the supported TiUp target triples. Version ids must be valid semver. Dependencies are a map from component id to a semver version string.
 
+The "nightly" points to the version number of latest daily build, that version should be in the version list of all supported platforms.
 
 ### snapshot.json
 

--- a/doc/design/manifest.md
+++ b/doc/design/manifest.md
@@ -255,22 +255,22 @@ Where xxx is the id of the component, n is the version of the manifest, file is 
 ```
 "name": "Name of the Component",
 "description": "This is a component",
-"nightly": "0.2.0-nightly-20200525",
+"nightly": "v0.2.0-nightly+20200525",
 "platforms": {
     "x86_64-apple-darwin": {
-        "0.0.1": {
+        "v0.0.1": {
             "yanked": false,
-            "url": "/name-of_x86_64-apple-darwin_0.0.1.tar.gz",
+            "url": "/name-of_x86_64-apple-darwin_v0.0.1.tar.gz",
             "hashes": {
                 "sha256": "141f740f53781d1ca54b8a50af22cbf74e44c21a998fa2a8a05aaac2c002886b",
                 "sha512": "ef5beafa16041bcdd2937140afebd485296cd54f7348ecd5a4d035c09759608de467a7ac0eb58753d0242df873c305e8bffad2454aa48f44480f15efae1cacd0"
             },
             "length": 1001000499,
             "dependencies": {
-                "foo": "1.0.0",
+                "foo": "v1.0.0",
             },
         },
-        "0.2.0": { ... },
+        "v0.2.0": { ... },
     },
     "aarch64-unknown-linux": { ... },
 },
@@ -278,7 +278,7 @@ Where xxx is the id of the component, n is the version of the manifest, file is 
 
 The platform id should be one of the supported TiUp target triples. Version ids must be valid semver. Dependencies are a map from component id to a semver version string.
 
-The "nightly" points to the version number of latest daily build, that version should be in the version list of all supported platforms. The version number of nightly build should (but not forced to be) in the following format:
+The "nightly" points to the version number of latest daily build, that version should be in the version list of all supported platforms. The version number of nightly build should (but not forced to) be in the following format:
 
 ```
 vX.Y.Z-nightly+YYYYmmdd

--- a/doc/design/manifest.md
+++ b/doc/design/manifest.md
@@ -281,7 +281,7 @@ The platform id should be one of the supported TiUp target triples. Version ids 
 The "nightly" points to the version number of latest daily build, that version should be in the version list of all supported platforms. The version number of nightly build should (but not forced to) be in the following format:
 
 ```
-vX.Y.Z-nightly+YYYYmmdd
+vX.Y.Z-nightly-YYYY-mm-dd
 ```
 
 Where `vX.Y.Z` is the version of the last released version of that component.

--- a/pkg/repository/v1manifest/types.go
+++ b/pkg/repository/v1manifest/types.go
@@ -106,7 +106,7 @@ type Component struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	NightlyVer  string `json:"nightly"` // version of the latest daily build
+	Nightly     string `json:"nightly"` // version of the latest daily build
 	// platform -> version -> VersionItem
 	Platforms map[string]map[string]VersionItem `json:"platforms"`
 }

--- a/pkg/repository/v1manifest/types.go
+++ b/pkg/repository/v1manifest/types.go
@@ -106,6 +106,7 @@ type Component struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	NightlyVer  string `json:"nightly"` // version of the latest daily build
 	// platform -> version -> VersionItem
 	Platforms map[string]map[string]VersionItem `json:"platforms"`
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add basic support of "nightly" versions to manifest definition and the migrate tool

### What is changed and how it works?
 - Add a "nightly" section to component manifest, that points to the latest daily build
 - Add support of migrating nightly builds from v0 manifest

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has persistent data change

Side effects

 - Increased code complexity

Related changes

 - Need to update the documentation
