### PR TITLE
Misc security fixes and tidying up for v1 manifests

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -60,11 +60,13 @@ func cleanData(env *meta.Environment, names []string, all bool) error {
 		if !all && !clean.Exist(dir.Name()) {
 			continue
 		}
-		metaFile := filepath.Join(localdata.DataParentDir, dir.Name(), localdata.MetaFilename)
-		var process process
-		err := env.Profile().ReadJSON(metaFile, &process)
+
+		process, err := env.Profile().ReadMetaFile(dir.Name())
 		if err != nil {
 			return err
+		}
+		if process == nil {
+			continue
 		}
 
 		if p, err := gops.NewProcess(int32(process.Pid)); err == nil {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -54,19 +54,17 @@ func showStatus(env *meta.Environment) error {
 			if !dir.IsDir() {
 				continue
 			}
-			metaFile := filepath.Join(localdata.DataParentDir, dir.Name(), localdata.MetaFilename)
 
-			// If the path doesn't contain the meta file, which means startup interrupted
-			if utils.IsNotExist(env.LocalPath(metaFile)) {
+			process, err := env.Profile().ReadMetaFile(dir.Name())
+			if err != nil {
+				return err
+			}
+			if process == nil {
+				// If the path doesn't contain the meta file, which means startup interrupted
 				_ = os.RemoveAll(env.LocalPath(filepath.Join(localdata.DataParentDir, dir.Name())))
 				continue
 			}
 
-			var process process
-			err := env.Profile().ReadJSON(metaFile, &process)
-			if err != nil {
-				return err
-			}
 			status := "TERM"
 			if exist, err := gops.PidExists(int32(process.Pid)); err == nil && exist {
 				status = "RUNNING"

--- a/doc/design/manifest.md
+++ b/doc/design/manifest.md
@@ -108,10 +108,6 @@ A key definition is:
 
 ```json
 "KEYID": {
-    "keyid_hash_algorithms": [
-        "sha256",
-        "sha512",
-    ],
     "keytype": "ed25519",
     "keyval": {
         "public": "KEY",
@@ -204,10 +200,6 @@ Example:
         "threshold": 1,
         "keys": {
             "4e777de0d275f9d28588dd9a1606cc748e548f9e22b6795b7cb3f63f98035fcb": {
-                "keyid_hash_algorithms": [
-                    "sha256",
-                    "sha512",
-                ],
                 "keytype": "rsa",
                 "keyval": {
                     "public": "-----BEGIN PUBLIC KEY-----\nMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA0GjPoVrjS9eCqzoQ8VRe\nPkC0cI6ktiEgqPfHESFzyxyjC490Cuy19nuxPcJuZfN64MC48oOkR+W2mq4pM51i\nxmdG5xjvNOBRkJ5wUCc8fDCltMUTBlqt9y5eLsf/4/EoBU+zC4SW1iPU++mCsity\nfQQ7U6LOn3EYCyrkH51hZ/dvKC4o9TPYMVxNecJ3CL1q02Q145JlyjBTuM3Xdqsa\nndTHoXSRPmmzgB/1dL/c4QjMnCowrKW06mFLq9RAYGIaJWfM/0CbrOJpVDkATmEc\nMdpGJYDfW/sRQvRdlHNPo24ZW7vkQUCqdRxvnTWkK5U81y7RtjLt1yskbWXBIbOV\nz94GXsgyzANyCT9qRjHXDDz2mkLq+9I2iKtEqaEePcWRu3H6RLahpM/TxFzw684Y\nR47weXdDecPNxWyiWiyMGStRFP4Cg9trcwAGnEm1w8R2ggmWphznCd5dXGhPNjfA\na82yNFY8ubnOUVJOf0nXGg3Edw9iY3xyjJb2+nrsk5f3AgMBAAE=\n-----END PUBLIC KEY-----",
@@ -215,10 +207,6 @@ Example:
                 "scheme": "rsassa-pss-sha256",
             },
             "59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d": {
-                "keyid_hash_algorithms": [
-                    "sha256",
-                    "sha512",
-                ],
                 "keytype": "ed25519",
                 "keyval": {
                     "public": "edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd",

--- a/pkg/repository/v1_repository_test.go
+++ b/pkg/repository/v1_repository_test.go
@@ -663,7 +663,7 @@ func setNewRoot(t *testing.T, local *v1manifest.MockManifests) crypto.PrivKey {
 func setRoot(local *v1manifest.MockManifests, root *v1manifest.Root) {
 	local.Manifests[v1manifest.ManifestFilenameRoot] = root
 	for r, ks := range root.Roles {
-		local.Ks.AddKeys(r, 1, ks.Keys)
+		local.Ks.AddKeys(r, 1, "2220-05-11T04:51:08Z", ks.Keys)
 	}
 }
 

--- a/pkg/repository/v1manifest/local_manifests.go
+++ b/pkg/repository/v1manifest/local_manifests.go
@@ -62,21 +62,24 @@ type FsManifests struct {
 // FIXME implement garbage collection of old manifests
 
 // NewManifests creates a new FsManifests with local store at root.
-// There must exists the trusted root.json.
+// There must exist a trusted root.json.
 func NewManifests(profile *localdata.Profile) (*FsManifests, error) {
 	result := &FsManifests{profile: profile, keys: NewKeyStore(), cache: make(map[string]string)}
 
+	// Load the root manifest.
 	manifest, err := result.load(ManifestFilenameRoot)
 	if err != nil {
 		return nil, err
 	}
 
+	// We must load without validation because we have no keys yet.
 	var root Root
 	err = ReadNoVerify(strings.NewReader(manifest), &root)
 	if err != nil {
 		return nil, err
 	}
 
+	// Populate our key store from the root manifest.
 	err = loadKeys(&root, result.keys)
 	if err != nil {
 		return nil, err

--- a/pkg/repository/v1manifest/manifest.go
+++ b/pkg/repository/v1manifest/manifest.go
@@ -410,7 +410,7 @@ func ReadManifest(input io.Reader, role ValidManifest, keys *KeyStore) (*Manifes
 			return nil, errors.Trace(err)
 		}
 
-		err = keys.transitionRoot(bytes, threshold, m.Signatures, newRoot.Roles[ManifestTypeRoot].Keys)
+		err = keys.transitionRoot(bytes, threshold, newRoot.Expires, m.Signatures, newRoot.Roles[ManifestTypeRoot].Keys)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -430,14 +430,14 @@ func loadKeys(manifest ValidManifest, ks *KeyStore) error {
 	case "root":
 		root := manifest.(*Root)
 		for name, role := range root.Roles {
-			if err := ks.AddKeys(name, role.Threshold, role.Keys); err != nil {
+			if err := ks.AddKeys(name, role.Threshold, manifest.Base().Expires, role.Keys); err != nil {
 				return errors.Trace(err)
 			}
 		}
 	case "index":
 		index := manifest.(*Index)
 		for name, owner := range index.Owners {
-			if err := ks.AddKeys(name, uint(owner.Threshold), owner.Keys); err != nil {
+			if err := ks.AddKeys(name, uint(owner.Threshold), manifest.Base().Expires, owner.Keys); err != nil {
 				return errors.Trace(err)
 			}
 		}


### PR DESCRIPTION
This PR is a bit of a bag of different things I found while checking we were properly doing signature and hash verification. It includes:

* Handling verification of expired root manifests by checking keys for expiry when they are used, not when loaded.
* Make `ReadJSON` in `Profile` private to reduce the surface area of json decoding. I have checked that every place where we decode JSON verifies the result if necessary. I created a `ReadMetaFile` function to accomplish this, I think it is a good abstraction in any case.
* Removed some mention of `sha512` hashes which we do not support.
* Removed the unused `DownloadComponent` from `v1Repository`
* Removed an unnecessary reload of the root manifest in `ensureManifests`, this was a mistake from a previous PR (whoops).

PTAL @lucklove @july2993 