### PR TITLE
manifest: extend the expire time of snapshot and timestamp

### DIFF
--- a/pkg/repository/v1manifest/manifest.go
+++ b/pkg/repository/v1manifest/manifest.go
@@ -17,12 +17,12 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"github.com/pingcap-incubator/tiup/pkg/set"
 	"io"
 	"strings"
 	"time"
 
 	cjson "github.com/gibson042/canonicaljson-go"
+	"github.com/pingcap-incubator/tiup/pkg/set"
 	"github.com/pingcap/errors"
 )
 
@@ -83,13 +83,13 @@ var ManifestsConfig = map[string]ty{
 	ManifestTypeSnapshot: {
 		Filename:  ManifestFilenameSnapshot,
 		Versioned: false,
-		Expire:    time.Hour * 24, // 1d
+		Expire:    time.Hour * 24 * 30, // 1mon, should be changed to 1d
 		Threshold: 1,
 	},
 	ManifestTypeTimestamp: {
 		Filename:  ManifestFilenameTimestamp,
 		Versioned: false,
-		Expire:    time.Hour * 24, // 1d
+		Expire:    time.Hour * 24 * 30, // 1mon, should be changed to 1d
 		Threshold: 1,
 	},
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Extend the expire time to 1 month

### What is changed and how it works?
Extend the expire time of snapshot and timestamp to 1mon, we'll need to change them back to 24 hours when everything is stable

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
