### PR TITLE
Remove name field from component manifest

### DIFF
--- a/doc/design/manifest.md
+++ b/doc/design/manifest.md
@@ -241,7 +241,6 @@ Each owner id and component id must be unique (TiUp should treat owner and compo
 Where xxx is the id of the component, n is the version of the manifest, file is immutable.
 
 ```
-"name": "Name of the Component",
 "description": "This is a component",
 "nightly": "v0.2.0-nightly+20200525",
 "platforms": {

--- a/pkg/repository/v1_repository_test.go
+++ b/pkg/repository/v1_repository_test.go
@@ -543,7 +543,6 @@ func componentManifest() *v1manifest.Component {
 			Version:     7,
 		},
 		ID:          "foo",
-		Name:        "Foo",
 		Description: "foo does stuff",
 		Platforms: map[string]map[string]v1manifest.VersionItem{
 			"plat/form": {"v2.0.1": versionItem()},

--- a/pkg/repository/v1manifest/repo.go
+++ b/pkg/repository/v1manifest/repo.go
@@ -219,7 +219,7 @@ NextKey:
 }
 
 // AddComponent adds a new component to an existing repository
-func AddComponent(id, name, desc, owner, repo string, isDefault bool, pub, priv string) error {
+func AddComponent(id, desc, owner, repo string, isDefault bool, pub, priv string) error {
 	// read key files
 	privBytes, err := ioutil.ReadFile(priv)
 	if err != nil {
@@ -248,7 +248,7 @@ func AddComponent(id, name, desc, owner, repo string, isDefault bool, pub, priv 
 
 	// create new component manifest
 	currTime := time.Now().UTC()
-	comp := NewComponent(id, name, desc, currTime)
+	comp := NewComponent(id, desc, currTime)
 	manifests[id] = comp
 	signedManifests[id], err = SignManifest(comp, privKey)
 	if err != nil {
@@ -351,7 +351,7 @@ func NewTimestamp(initTime time.Time) *Timestamp {
 }
 
 // NewComponent creates a Component object
-func NewComponent(id, name, desc string, initTime time.Time) *Component {
+func NewComponent(id, desc string, initTime time.Time) *Component {
 	return &Component{
 		SignedBase: SignedBase{
 			Ty:          ManifestTypeComponent,
@@ -360,7 +360,6 @@ func NewComponent(id, name, desc string, initTime time.Time) *Component {
 			Version:     1,
 		},
 		ID:          id,
-		Name:        name,
 		Description: desc,
 		Platforms:   make(map[string]map[string]VersionItem),
 	}

--- a/pkg/repository/v1manifest/types.go
+++ b/pkg/repository/v1manifest/types.go
@@ -104,7 +104,6 @@ type VersionItem struct {
 type Component struct {
 	SignedBase
 	ID          string `json:"id"`
-	Name        string `json:"name"`
 	Description string `json:"description"`
 	Nightly     string `json:"nightly"` // version of the latest daily build
 	// platform -> version -> VersionItem

--- a/tools/migrate/main.go
+++ b/tools/migrate/main.go
@@ -357,7 +357,6 @@ func migrate(srcDir, dstDir string) error {
 				Version:     1, // initial repo starts with version 1
 			},
 			ID:          comp.Name,
-			Name:        comp.Name,
 			Description: comp.Desc,
 			Nightly:     nightlyVer,
 			Platforms:   platforms,


### PR DESCRIPTION
I think we should not have both name and id, it is confusing and has potential for errors where one is required but the other is used.

PTAL @lonng 