### PR TITLE
tools/migrate: add function to rehash tarballs and update with existing keys

### DIFF
--- a/pkg/repository/clone_mirror.go
+++ b/pkg/repository/clone_mirror.go
@@ -201,16 +201,11 @@ func CloneMirror(repo *V1Repository, components []string, targetDir string, sele
 		return err
 	}
 
-	hash, _, err := HashManifest(signedManifests[v1manifest.ManifestTypeSnapshot])
+	timestamp, err = timestamp.SetSnapshot(signedManifests[v1manifest.ManifestTypeSnapshot])
 	if err != nil {
 		return errors.Trace(err)
 	}
-	timestamp.Meta = map[string]v1manifest.FileHash{
-		v1manifest.ManifestURLSnapshot: {
-			Hashes: hash,
-			Length: limitLength,
-		},
-	}
+
 	signedManifests[v1manifest.ManifestTypeTimestamp], err = v1manifest.SignManifest(timestamp, keys[v1manifest.ManifestTypeTimestamp]...)
 	if err != nil {
 		return err

--- a/pkg/repository/hash.go
+++ b/pkg/repository/hash.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 
-	cjson "github.com/gibson042/canonicaljson-go"
 	"github.com/pingcap-incubator/tiup/pkg/repository/v1manifest"
 )
 
@@ -43,20 +42,4 @@ func HashFile(srcDir, filename string) (map[string]string, int64, error) {
 		v1manifest.SHA512: hex.EncodeToString(s512.Sum(nil)),
 	}
 	return hashes, n, err
-}
-
-// HashManifest returns the sha256/sha512 hashes and the file length of specific manifest
-func HashManifest(m *v1manifest.Manifest) (map[string]string, uint, error) {
-	bytes, err := cjson.Marshal(m)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	s256 := sha256.Sum256(bytes)
-	s512 := sha512.Sum512(bytes)
-
-	return map[string]string{
-		v1manifest.SHA256: hex.EncodeToString(s256[:]),
-		v1manifest.SHA512: hex.EncodeToString(s512[:]),
-	}, uint(len(bytes)), nil
 }

--- a/pkg/repository/v1manifest/keys.go
+++ b/pkg/repository/v1manifest/keys.go
@@ -22,6 +22,9 @@ import (
 	"github.com/pingcap/errors"
 )
 
+// ShortKeyIDLength is the number of bytes used for filenames
+const ShortKeyIDLength = 16
+
 // ErrorNotPrivateKey indicate that it need a private key, but the supplied is not.
 var ErrorNotPrivateKey = errors.New("not a private key")
 

--- a/pkg/repository/v1manifest/repo.go
+++ b/pkg/repository/v1manifest/repo.go
@@ -114,7 +114,7 @@ func SaveKeyInfo(key *KeyInfo, ty, dir string) error {
 		return err
 	}
 
-	f, err := os.Create(path.Join(dir, fmt.Sprintf("%s-%s.json", id[:16], ty)))
+	f, err := os.Create(path.Join(dir, fmt.Sprintf("%s-%s.json", id[:ShortKeyIDLength], ty)))
 	if err != nil {
 		return err
 	}

--- a/pkg/repository/v1manifest/repo.go
+++ b/pkg/repository/v1manifest/repo.go
@@ -396,7 +396,7 @@ func (manifest *Timestamp) SetSnapshot(s *Manifest) (*Timestamp, error) {
 	if manifest.Meta == nil {
 		manifest.Meta = make(map[string]FileHash)
 	}
-	manifest.Meta[s.Signed.Base().Filename()] = FileHash{
+	manifest.Meta[fmt.Sprintf("/%s", s.Signed.Base().Filename())] = FileHash{
 		Hashes: map[string]string{
 			SHA256: hex.EncodeToString(hash256[:]),
 			SHA512: hex.EncodeToString(hash512[:]),


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Update an exist repo (generated by `migrate new`) without regenerating root.json and keys.

This is useful when some of the files in repository has changed, or when the v0 manifest has changed, but there is already a v1 repository generated and it's not convenient to resign the `root.json` with keys held by different individuals.

### What is changed and how it works?
Add a `migrate rehash` command, it reads the `root.json` and `index.json` and then find keys for other manifests. Then it performs operations similar as `migrate new` but without generating new keys.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has persistent data change

Side effects

 - Increased code complexity

Related changes

 - Need to update the documentation
