### PR TITLE
Don't report errors if some components don't have a nightly version.

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -20,13 +20,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pingcap/errors"
-
 	"github.com/pingcap-incubator/tiup/pkg/localdata"
 	"github.com/pingcap-incubator/tiup/pkg/repository"
 	"github.com/pingcap-incubator/tiup/pkg/repository/v0manifest"
 	"github.com/pingcap-incubator/tiup/pkg/repository/v1manifest"
 	"github.com/pingcap-incubator/tiup/pkg/version"
+	"github.com/pingcap/errors"
 	"golang.org/x/mod/semver"
 )
 

--- a/pkg/repository/progress.go
+++ b/pkg/repository/progress.go
@@ -33,11 +33,13 @@ func (d DisableProgress) Finish() {}
 
 // ProgressBar implement the DownloadProgress interface with download progress
 type ProgressBar struct {
-	bar *pb.ProgressBar
+	bar  *pb.ProgressBar
+	size int64
 }
 
 // Start implement the DownloadProgress interface
 func (p *ProgressBar) Start(url string, size int64) {
+	p.size = size
 	p.bar = pb.Start64(size)
 	p.bar.Set(pb.Bytes, true)
 	p.bar.SetTemplateString(fmt.Sprintf(`download %s {{counters . }} {{percent . }} {{speed . }}`, url))
@@ -50,5 +52,6 @@ func (p *ProgressBar) SetCurrent(size int64) {
 
 // Finish implement the DownloadProgress interface
 func (p *ProgressBar) Finish() {
+	p.bar.SetCurrent(p.size)
 	p.bar.Finish()
 }

--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -103,7 +103,7 @@ func (r *V1Repository) UpdateComponents(specs []ComponentSpec) error {
 		}
 
 		if spec.Nightly && !manifest.HasNightly(r.PlatformString()) {
-			errs = append(errs, fmt.Sprintf("the component `%s` does not have a nightly version; skipped", spec.ID))
+			fmt.Printf("The component `%s` does not have a nightly version; skipped\n", spec.ID)
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
download http://172.16.5.134:8989/pd-nightly-linux-amd64.tar.gz 37.35 MiB / 37.36 MiB 99.99% 993.56 KiB p/s
download http://172.16.5.134:8989/tidb-nightly-linux-amd64.tar.gz 41.06 MiB / 41.06 MiB 99.99% 885.73 KiB p/s
download http://172.16.5.134:8989/tikv-nightly-linux-amd64.tar.gz 131.15 MiB / 131.15 MiB 100.00% 927.64 KiB p/s
Error: the component `mirrors` does not have a nightly version; skipped
the component `playground` does not have a nightly version; skipped
```

### What is changed and how it works?

Don't report errors if some components don't have a nightly version.
