### PR TITLE
tools/migrate: fix version and expire time of updated manfiests

### DIFF
--- a/pkg/repository/v1manifest/manifest.go
+++ b/pkg/repository/v1manifest/manifest.go
@@ -426,6 +426,13 @@ func ReadManifest(input io.Reader, role ValidManifest, keys *KeyStore) (*Manifes
 	return m, m.Signed.isValid()
 }
 
+// RenewManifest resets and extends the expire time of manifest
+func RenewManifest(m ValidManifest, startTime time.Time) {
+	m.Base().Expires = startTime.Add(
+		ManifestsConfig[m.Base().Ty].Expire,
+	).Format(time.RFC3339)
+}
+
 // loadKeys stores all keys declared in manifest into ks.
 func loadKeys(manifest ValidManifest, ks *KeyStore) error {
 	switch manifest.Base().Ty {


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The version and expire time of `index.json` is not correctly set on update. Also fixes wrong expire time of `snapshot.json`.

### What is changed and how it works?
Update values for exist manifests

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has persistent data change

