### PR TITLE
Don't report error when installing exists version

### DIFF
--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -126,7 +126,7 @@ func (r *V1Repository) UpdateComponents(specs []ComponentSpec) error {
 				return errors.Trace(err)
 			}
 			if installed {
-				errs = append(errs, fmt.Sprintf("component %s version %s is already installed", spec.ID, version))
+				fmt.Printf("component %s version %s is already installed\n", spec.ID, version)
 				continue
 			}
 		}

--- a/pkg/repository/v1_repository_test.go
+++ b/pkg/repository/v1_repository_test.go
@@ -435,7 +435,7 @@ func TestUpdateComponents(t *testing.T) {
 	err = repo.UpdateComponents([]ComponentSpec{{
 		ID: "foo",
 	}})
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, 1, len(local.Installed))
 	assert.Equal(t, "v2.0.2", local.Installed["foo"].Version)
 	assert.Equal(t, "foo202", local.Installed["foo"].Contents)
@@ -485,7 +485,7 @@ func TestUpdateComponents(t *testing.T) {
 		ID:      "foo",
 		Version: "v2.0.1",
 	}})
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, 1, len(local.Installed))
 	assert.Equal(t, "v2.0.1", local.Installed["foo"].Version)
 	assert.Equal(t, "foo201", local.Installed["foo"].Contents)


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Don't report error when installing exists version.

```
➜  tiup git:(verbose-list) tiup install tidb:v3.0.11 tikv:nightly pd:v4.0.0-rc.1
download http://172.16.5.134:8989/pd-v4.0.0-rc.1-darwin-amd64.tar.gz 37.88 MiB / 37.88 MiB 100.00% 7.59 MiB p/s                                                                                            
Error: component tidb version v3.0.11 is already installed
component tikv version nightly is already installed
➜  tiup git:(verbose-list) git branch -b verbose-list  
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```
➜  tiup git:(fix-install) ✗ tiup install tidb:v3.0.11 tikv:nightly pd:v4.0.0-rc.1
component tidb version v3.0.11 is already installed
component tikv version nightly is already installed
component pd version v4.0.0-rc.1 is already installed
```
