### PR TITLE
attach the mirror source information into error message

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -20,14 +20,11 @@ import (
 	"sort"
 	"time"
 
-	"github.com/pingcap-incubator/tiup/pkg/repository"
-
-	"github.com/fatih/color"
-
 	"github.com/pingcap-incubator/tiup/pkg/meta"
+	"github.com/pingcap-incubator/tiup/pkg/repository"
 	"github.com/pingcap-incubator/tiup/pkg/repository/v1manifest"
 	"github.com/pingcap-incubator/tiup/pkg/utils"
-	"github.com/pkg/errors"
+	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -394,10 +391,7 @@ func newMirrorCloneCmd(env *meta.Environment) *cobra.Command {
 	}
 
 	repo := env.V1Repository()
-	index, err := repo.FetchIndexManifest()
-	if err != nil {
-		fmt.Println(color.YellowString("Warning: cannot fetch component list from mirror: %v", err))
-	}
+	index, fetchErr := repo.FetchIndexManifest()
 
 	var components []string
 	if index != nil && len(index.Components) > 0 {
@@ -418,6 +412,10 @@ func newMirrorCloneCmd(env *meta.Environment) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return cmd.Help()
+			}
+
+			if fetchErr != nil {
+				return errors.AddStack(fetchErr)
 			}
 
 			if len(components) < 1 {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -68,7 +68,7 @@ func InitEnv(options repository.Options) (*Environment, error) {
 		var local v1manifest.LocalManifests
 		local, err = v1manifest.NewManifests(profile)
 		if err != nil {
-			return nil, errors.AddStack(err)
+			return nil, errors.Annotatef(err, "initial repository from mirror(%s) failed", Mirror())
 		}
 		v1repo = repository.NewV1Repo(mirror, options, local)
 	} else {

--- a/pkg/repository/mirror.go
+++ b/pkg/repository/mirror.go
@@ -270,6 +270,11 @@ type MockMirror struct {
 	Resources map[string]string
 }
 
+// Source implements the Mirror interface
+func (l *MockMirror) Source() string {
+	return "mock"
+}
+
 // Open implements Mirror.
 func (l *MockMirror) Open() error {
 	return nil

--- a/pkg/repository/mirror.go
+++ b/pkg/repository/mirror.go
@@ -50,6 +50,8 @@ type (
 	// Mirror represents a repository mirror, which can be remote HTTP
 	// server or a local file system directory
 	Mirror interface {
+		// Source returns the address of the mirror
+		Source() string
 		// Open initialize the mirror.
 		Open() error
 		// Download fetches a resource to disk.
@@ -80,6 +82,11 @@ func NewMirror(mirror string, options MirrorOptions) Mirror {
 
 type localFilesystem struct {
 	rootPath string
+}
+
+// Source implements the Mirror interface
+func (l *localFilesystem) Source() string {
+	return l.rootPath
 }
 
 // Open implements the Mirror interface
@@ -145,6 +152,11 @@ type httpMirror struct {
 	server  string
 	tmpDir  string
 	options MirrorOptions
+}
+
+// Source implements the Mirror interface
+func (l *httpMirror) Source() string {
+	return l.server
 }
 
 // Open implements the Mirror interface

--- a/pkg/repository/v1_repository.go
+++ b/pkg/repository/v1_repository.go
@@ -495,11 +495,15 @@ func (r *V1Repository) fetchManifestWithHash(url string, role v1manifest.ValidMa
 func (r *V1Repository) fetchBase(url string, maxSize uint, f func(reader io.Reader) (*v1manifest.Manifest, error)) (*v1manifest.Manifest, error) {
 	reader, err := r.mirror.Fetch(url, int64(maxSize))
 	if err != nil {
-		return nil, errors.Annotatef(err, "fetch %s failed", url)
+		return nil, errors.Annotatef(err, "fetch %s from mirror(%s) failed", url, r.mirror.Source())
 	}
 	defer reader.Close()
 
-	return f(reader)
+	m, err := f(reader)
+	if err != nil {
+		return nil, errors.Annotatef(err, "read manifest from mirror(%s) failed", r.mirror.Source())
+	}
+	return m, nil
 }
 
 func checkHash(reader io.Reader, sha256 string) (io.Reader, error) {


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

attach the mirror source information into the error message.

```
➜  tiup git:(attach-mirror-addr) ✗ tiup list
Error: read manifest from mirror(/c/devel/pingcap/tiup/localpath) failed: not enough signatures (0) for threshold 1 in timestamp.json
```