### PR TITLE
upgrade golang-ci and enable all default linter.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,17 +29,10 @@ default: cmd check
 cmd:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tiup
 
-check: fmt errcheck lint tidy check-static vet staticcheck
-
-errcheck:tools/bin/errcheck
-	@echo "errcheck"
-	@GO111MODULE=on tools/bin/errcheck -exclude ./tools/check/errcheck_excludes.txt -ignoretests -blank $(PACKAGES)
+check: fmt lint tidy check-static vet
 
 check-static: tools/bin/golangci-lint
-	tools/bin/golangci-lint run -v --disable-all --deadline=3m \
-	  --enable=misspell \
-	  --enable=ineffassign \
-	  $$($(PACKAGE_DIRECTORIES))
+	tools/bin/golangci-lint run ./... --deadline=3m
 
 lint:tools/bin/revive
 	@echo "linting"
@@ -47,10 +40,6 @@ lint:tools/bin/revive
 
 vet:
 	$(GO) vet ./...
-
-staticcheck:
-	$(GO) get honnef.co/go/tools/cmd/staticcheck
-	GO111MODULE=on staticcheck ./...
 
 tidy:
 	@echo "go mod tidy"
@@ -164,5 +153,5 @@ tools/bin/revive: tools/check/go.mod
 	$(GO) build -o ../bin/revive github.com/mgechev/revive
 
 tools/bin/golangci-lint:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.21.0
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.27.0
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -20,8 +20,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/pingcap-incubator/tiup/pkg/localdata"
-	"github.com/pingcap-incubator/tiup/pkg/meta"
 	"github.com/pingcap-incubator/tiup/pkg/repository"
 	. "github.com/pingcap/check"
 )
@@ -47,6 +45,7 @@ func (s *testCmdSuite) SetUpSuite(c *C) {
 	s.mirror = repository.NewMirror(s.testDir, repository.MirrorOptions{})
 }
 
+/*
 func (s *testCmdSuite) newEnv(c *C) *meta.Environment {
 	repo, err := repository.NewRepository(s.mirror, repository.Options{})
 	c.Assert(err, IsNil)
@@ -57,6 +56,7 @@ func (s *testCmdSuite) newEnv(c *C) *meta.Environment {
 
 	return meta.NewV0(profile, repo)
 }
+*/
 
 func (s *testCmdSuite) TearDownSuite(c *C) {
 	s.mirror.Close()

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -94,6 +94,7 @@ func externalHelp(env *meta.Environment, spec string, args ...string) {
 	}
 }
 
+// nolint unused
 func rebuildArgs(args []string) []string {
 	helpFlag := "--help"
 	argList := []string{}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -87,7 +87,7 @@ func (lr *listResult) print() {
 }
 
 func showComponentList(env *meta.Environment, opt listOptions) (*listResult, error) {
-	index := new(v1manifest.Index)
+	var index *v1manifest.Index
 	var err error
 	index, err = env.V1Repository().FetchIndexManifest()
 	if err != nil {
@@ -152,13 +152,13 @@ func showComponentList(env *meta.Environment, opt listOptions) (*listResult, err
 	}
 
 	return &listResult{
-		header:   fmt.Sprintf("Available components:\n"),
+		header:   "Available components:\n",
 		cmpTable: cmpTable,
 	}, nil
 }
 
 func showComponentVersions(env *meta.Environment, component string, opt listOptions) (*listResult, error) {
-	comp := new(v1manifest.Component)
+	var comp *v1manifest.Component
 	var err error
 	comp, err = env.V1Repository().FetchComponentManifest(component)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,7 +127,7 @@ the latest stable version will be downloaded from the repository.`,
 			externalHelp(env, n[0], n[1:]...)
 		} else {
 			cmd.InitDefaultHelpFlag() // make possible 'help' flag to be shown
-			cmd.Help()
+			_ = cmd.Help()
 		}
 	})
 	rootCmd.SetHelpCommand(newHelpCmd(env))

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -11,8 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var telemetryCmd *cobra.Command
-
 const telemetryFname = "meta.yaml"
 
 func getTelemetryMeta(env *meta.Environment) (meta *telemetry.Meta, fname string, err error) {

--- a/components/bench/main.go
+++ b/components/bench/main.go
@@ -135,7 +135,10 @@ func main() {
 		}
 	}()
 
-	rootCmd.Execute()
-
-	cancel()
+	defer cancel()
+	err := rootCmd.Execute()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/components/bench/tpcc.go
+++ b/components/bench/tpcc.go
@@ -18,7 +18,10 @@ var tpccConfig tpcc.Config
 func executeTpcc(action string) {
 	if pprofAddr != "" {
 		go func() {
-			http.ListenAndServe(pprofAddr, http.DefaultServeMux)
+			err := http.ListenAndServe(pprofAddr, http.DefaultServeMux)
+			if err != nil {
+				fmt.Printf("failed to ListenAndServe: %s\n", err.Error())
+			}
 		}()
 	}
 	runtime.GOMAXPROCS(maxProcs)

--- a/components/client/main.go
+++ b/components/client/main.go
@@ -203,7 +203,7 @@ func selectEndpoint(endpoints []*endpoint) *endpoint {
 	uiEvents := ui.PollEvents()
 	for {
 		e := <-uiEvents
-		ioutil.WriteFile("/tmp/log", []byte(e.ID+"\n"), 0664)
+		_ = ioutil.WriteFile("/tmp/log", []byte(e.ID+"\n"), 0664)
 		switch e.ID {
 		case "q", "<C-c>":
 			return nil

--- a/components/playground/main.go
+++ b/components/playground/main.go
@@ -215,10 +215,7 @@ func hasDashboard(pdAddr string) bool {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 200 {
-		return true
-	}
-	return false
+	return resp.StatusCode == 200
 }
 
 func getAbsolutePath(binPath string) string {
@@ -398,6 +395,8 @@ func bootCluster(options *bootOptions) error {
 	}
 
 	for i, inst := range all {
+		// nolint
+		// SA1029: should not use built-in type string as key for value; define your own type to avoid collisions.
 		if err := inst.Start(context.WithValue(ctx, "has_tiflash", options.tiflashNum > 0), v0manifest.Version(options.version), pathMap[allRole[i]], profile); err != nil {
 			return err
 		}
@@ -431,7 +430,7 @@ func bootCluster(options *bootOptions) error {
 				if err != nil {
 					fmt.Println("Set the PD metrics storage failed")
 				}
-				fmt.Printf(color.GreenString("To view the monitor: http://%s:%d\n", monitorInfo.IP, monitorInfo.Port))
+				fmt.Print(color.GreenString("To view the monitor: http://%s:%d\n", monitorInfo.IP, monitorInfo.Port))
 			}
 		}
 	}

--- a/tools/migrate/main.go
+++ b/tools/migrate/main.go
@@ -239,7 +239,7 @@ func migrate(srcDir, dstDir string, rehash bool) error {
 				if err != nil {
 					return err
 				}
-				if json.Unmarshal(bytes, pk); err != nil {
+				if err = json.Unmarshal(bytes, pk); err != nil {
 					return err
 				}
 				privKi = append(privKi, pk)
@@ -291,7 +291,7 @@ func migrate(srcDir, dstDir string, rehash bool) error {
 			if err != nil {
 				return err
 			}
-			if json.Unmarshal(bytes, ownerkeyInfo); err != nil {
+			if err = json.Unmarshal(bytes, ownerkeyInfo); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
upgrade golang-ci and enable all default linter.

<img width="1038" alt="Screen Shot 2020-05-28 at 11 50 07 AM" src="https://user-images.githubusercontent.com/1681864/83096890-64571f00-a0d9-11ea-95c2-7be874afd865.png">

you may need to delete `tools/bin/golangci-lint` for it to reinstall the new version one.