### PR TITLE
Add --prefix option for tiup mirror clone

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -481,7 +481,7 @@ func newMirrorCloneCmd(env *meta.Environment) *cobra.Command {
 		Use: "clone <target-dir> [global version]",
 		Example: `  tiup mirror clone /path/to/local --arch amd64,arm --os linux,darwin    # Specify the architectures and OSs
   tiup mirror clone /path/to/local --full                                # Build a full local mirror
-  tiup mirror clone /path/to/local --tikv v4                             # Specify the version via prefix
+  tiup mirror clone /path/to/local --tikv v4  --prefix                   # Specify the version via prefix
   tiup mirror clone /path/to/local --tidb all --pd all                   # Download all version for specific component`,
 		Short:        "Clone a local mirror from remote mirror and download all selected components",
 		SilenceUsage: true,
@@ -511,6 +511,7 @@ func newMirrorCloneCmd(env *meta.Environment) *cobra.Command {
 	cmd.Flags().BoolVarP(&options.Full, "full", "f", false, "Build a full mirrors repository")
 	cmd.Flags().StringSliceVarP(&options.Archs, "arch", "a", []string{"amd64", "arm64"}, "Specify the downloading architecture")
 	cmd.Flags().StringSliceVarP(&options.OSs, "os", "o", []string{"linux", "darwin"}, "Specify the downloading os")
+	cmd.Flags().BoolVarP(&options.Prefix, "prefix", "", false, "Download the version with matching prefix")
 
 	for _, name := range components {
 		options.Components[name] = new([]string)

--- a/pkg/repository/clone_mirror.go
+++ b/pkg/repository/clone_mirror.go
@@ -39,6 +39,7 @@ type CloneOptions struct {
 	Versions   []string
 	Full       bool
 	Components map[string]*[]string
+	Prefix     bool
 }
 
 // CloneMirror clones a local mirror from the remote repository
@@ -375,7 +376,10 @@ func checkVersion(options CloneOptions, versions set.StringSet, version string) 
 	}
 	// prefix match
 	for v := range versions {
-		if strings.HasPrefix(version, v) {
+
+		if options.Prefix && strings.HasPrefix(version, v) {
+			return true
+		} else if version == v {
 			return true
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiUP! Please read TiUP's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
`tiup mirror clone <target-dir> [global version] [flags]` will download versions that matching specific version prefix.

### What is changed and how it works?
`tiup mirror clone <target-dir> [global version] [flags]` will download versions that match exactly by default. Users can use `--prefix` option to download versions that matching prefix if they want.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

```
tiup mirror clone package v4.0.0 --os=linux --prefix
tiup mirror clone package v4.0.0 --os=linux 
```



